### PR TITLE
report version from cargo.toml

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,16 @@ use std::process;
 use crate::hook::VariableOutputMode;
 
 fn main() {
+    let version = format!(
+        "{}.{}.{}{}",
+        env!("CARGO_PKG_VERSION_MAJOR"),
+        env!("CARGO_PKG_VERSION_MINOR"),
+        env!("CARGO_PKG_VERSION_PATCH"),
+        option_env!("CARGO_PKG_VERSION_PRE").unwrap_or("")
+    );
+
     let app_matches = App::new("shadowenv")
-        .version("0.0.1")
+        .version(&version[..])
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(
             SubCommand::with_name("hook")


### PR DESCRIPTION
Just copy/pasted from https://github.com/clap-rs/clap/issues/28 🤷‍♂️ 

`env!` runs at compile-time, 🎩 works.

fixes #8