### PR TITLE
Suppress errors on bash's DEBUG and zsh's preexec_functions:

### DIFF
--- a/sh/shadowenv.bash.in
+++ b/sh/shadowenv.bash.in
@@ -1,5 +1,9 @@
 __shadowenv_hook() {
-  "@SELF@" hook "${__shadowenv_data}" | source /dev/stdin
+  local flags; flags=()
+  if [[ "$1" == "bash-debug" ]]; then
+    flags=(--silent)
+  fi
+  "@SELF@" hook "${flags[@]}" "${__shadowenv_data:-}" | source /dev/stdin
 }
 
 # Hookbook (https://github.com/Shopify/hookbook)

--- a/sh/shadowenv.zsh.in
+++ b/sh/shadowenv.zsh.in
@@ -1,5 +1,9 @@
 __shadowenv_hook() {
-  "@SELF@" hook "${__shadowenv_data}" | source /dev/stdin
+  local flags; flags=()
+  if [[ "$1" == "zsh-preexec" ]]; then
+    flags=(--silent)
+  fi
+  "@SELF@" hook "${flags[@]}" "${__shadowenv_data:-}" | source /dev/stdin
 }
 
 # Hookbook (https://github.com/Shopify/hookbook)

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,11 @@ fn main() {
                         .help("Format variable assignments for fish shell"),
                 )
                 .arg(
+                    Arg::with_name("silent")
+                        .long("silent")
+                        .help("Suppress error printing"),
+                )
+                .arg(
                     Arg::with_name("porcelain")
                         .long("porcelain")
                         .help("Format variable assignments for machine parsing"),
@@ -92,7 +97,7 @@ fn main() {
                 },
             };
             if let Err(err) = hook::run(data, mode) {
-                process::exit(output::handle_hook_error(err));
+                process::exit(output::handle_hook_error(err, matches.is_present("silent")));
             }
         }
         ("trust", Some(_)) => {

--- a/src/output.rs
+++ b/src/output.rs
@@ -21,7 +21,11 @@ fn cooldown() -> Duration {
     Duration::new(COOLDOWN_SECONDS, 0)
 }
 
-pub fn handle_hook_error(err: Error) -> i32 {
+pub fn handle_hook_error(err: Error, silent: bool) -> i32 {
+    if silent {
+        return 1;
+    }
+
     if let Ok(true) = check_and_trigger_cooldown(&err) {
         return 1;
     };


### PR DESCRIPTION
Anything that's going to fail meaningfully is going to do it on the other hooks as well. This will prevent a confusing UX case outlined in https://github.com/Shopify/shadowenv/issues/12

![screen shot 2019-02-20 at 5 50 28 pm](https://user-images.githubusercontent.com/1284/53130445-4135db00-3538-11e9-944b-c57334ae8e98.png)

fixes #12