### PR TITLE
Preserve empty item in path list

### DIFF
--- a/src/shadowenv.rs
+++ b/src/shadowenv.rs
@@ -209,9 +209,6 @@ fn env_remove_from_pathlist_containing(
 fn env_prepend_to_pathlist(env: &mut RefMut<HashMap<String, String>>, a: String, b: String) -> () {
     let curr = env.get(&a).cloned().unwrap_or("".to_string());
     let mut items = curr.split(":").collect::<Vec<&str>>();
-    if items.len() == 1 && items[0] == "" {
-        items = vec![];
-    }
     items.insert(0, &b);
     let next = items.join(":");
     env.insert(a, next.to_string());


### PR DESCRIPTION
Fix issue where prepending to empty MANPATH would leave default man paths unused. (https://shopify.slack.com/archives/C030RFPKD/p1554742195823500)