### PR TITLE
Add append_to_pathlist

### DIFF
--- a/docs/shadowlisp.md
+++ b/docs/shadowlisp.md
@@ -113,6 +113,32 @@ If there are no items in the list currently, `env/prepend-to-pathlist` will simp
 |---|---|
 | `None` | Always returns `()` |
 
+## `env/append-to-pathlist`
+
+`(env/append-to-pathlist name entry)`
+
+```scheme
+(env/append-to-pathlist "PATH" "/opt/mytool/bin") ; ()
+```
+
+While less common than prepending, it's sometimes desirable to append an item to a `:`-delimited path (such as `PATH` or
+`MANPATH`), to add it as a lower priority option.  `env/append-to-pathlist` does precisely this, first removing the item
+from the path if it was already present, before appending it to the end of the pathlist.
+
+Strictly speaking, any variable can be treated as a pathlist by Shadowenv, but it only makes sense
+to do this for variables that other tools expect to contain multiple items.
+
+If there are no items in the list currently, `env/append-to-pathlist` will simply create the list with a single item.
+
+| Argument | Type | Description |
+|---|---|---|
+| name | `String` | Name of environment variable to change |
+| entry | `String` | String to append |
+
+| Return Type | Description |
+|---|---|
+| `None` | Always returns `()` |
+
 ## `env/remove-from-pathlist`
 
 ```scheme
@@ -125,8 +151,8 @@ If there are no items in the list currently, `env/prepend-to-pathlist` will simp
 (env/get "PATH") ; "/usr/bin:/bin"
 ```
 
-The counterpart to `env/prepend-to-pathlist` is this, `env-remove-from-pathlist`. This won't be as
-useful, since Shadowenv always takes care of its own deactivation, but you may occasionally want to
+The counterpart to `env/prepend-to-pathlist`/`env/append-to-pathlist` is this, `env-remove-from-pathlist`. This won't be
+as useful, since Shadowenv always takes care of its own deactivation, but you may occasionally want to
 deactivate certain system-wide configuration upon entry into a Shadowenv.
 
 If, after removing the indicated item from the specified pathlist, the variable becomes empty, it is

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -106,6 +106,25 @@ impl ShadowLang {
 
         interp
             .scope()
+            .add_value_with_name("env/append-to-pathlist", |name| {
+                Value::new_foreign_fn(name, move |ctx, args| {
+                    assert_args!(args, 2, name);
+
+                    let value = ctx
+                        .scope()
+                        .get_constant(shadowenv_name)
+                        .expect("bug: shadowenv not defined");
+                    let shadowenv = <&Shadowenv as FromValueRef>::from_value_ref(&value)?;
+                    let name = <&str as FromValueRef>::from_value_ref(&args[0])?;
+                    let value = <&str as FromValueRef>::from_value_ref(&args[1])?;
+
+                    shadowenv.append_to_pathlist(name, value);
+                    Ok(Value::Unit)
+                })
+            });
+
+        interp
+            .scope()
             .add_value_with_name("env/prepend-to-pathlist", |name| {
                 Value::new_foreign_fn(name, move |ctx, args| {
                     assert_args!(args, 2, name);

--- a/src/shadowenv.rs
+++ b/src/shadowenv.rs
@@ -131,6 +131,11 @@ impl Shadowenv {
         )
     }
 
+    pub fn append_to_pathlist(&self, a: &str, b: &str) -> () {
+        self.inform_list(a);
+        env_append_to_pathlist(&mut self.env.borrow_mut(), a.to_string(), b.to_string())
+    }
+
     pub fn prepend_to_pathlist(&self, a: &str, b: &str) -> () {
         self.inform_list(a);
         env_prepend_to_pathlist(&mut self.env.borrow_mut(), a.to_string(), b.to_string())
@@ -201,6 +206,15 @@ fn env_remove_from_pathlist_containing(
 
     let items = items.into_iter().skip_while(|x| (*x).contains(&b));
     let items: Vec<&str> = items.collect();
+    let next = items.join(":");
+    env.insert(a, next.to_string());
+    ()
+}
+
+fn env_append_to_pathlist(env: &mut RefMut<HashMap<String, String>>, a: String, b: String) -> () {
+    let curr = env.get(&a).cloned().unwrap_or("".to_string());
+    let mut items = curr.split(":").collect::<Vec<&str>>();
+    items.insert(items.len(), &b);
     let next = items.join(":");
     env.insert(a, next.to_string());
     ()


### PR DESCRIPTION
```
$ echo $PATH
/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
$ mkdir -p demo/.shadowenv.d
$ echo '(env/append-to-pathlist "PATH" "/sentinel")' > demo/.shadowenv.d/demo.lisp
$ cd demo
shadowenv failure: directory contains untrusted shadowenv program: shadowenv help trust to learn more.
$ shadowenv trust
activated shadowenv
$ echo $PATH
/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/sentinel
$ cd ..
deactivated shadowenv
$ echo $PATH
/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
```

It's worth noting that the behaviour is already allowed, this just makes it easier and more clear:
```lisp
(if (null (env/get "PATH"))
  (env/set "PATH" "/sentinel")
  (env/set "PATH" (concat (env/get "PATH") ":/sentinel" )))
```