### PR TITLE
Add shadowenv diff

### DIFF
--- a/sh/shadowenv.bash.in
+++ b/sh/shadowenv.bash.in
@@ -1,3 +1,7 @@
+shadowenv() {
+  [[ "$1" == "diff" ]] && "@SELF@" "$@" "${__shadowenv_data:-}" || "@SELF@" "$@"
+}
+
 __shadowenv_hook() {
   local flags; flags=(--shellpid "$$")
   if [[ "$1" == "bash-debug" ]]; then

--- a/sh/shadowenv.fish.in
+++ b/sh/shadowenv.fish.in
@@ -1,3 +1,11 @@
+function shadowenv
+  if test "$argv[1]" = "diff"
+    "@SELF@" $argv "$__shadowenv_data"
+  else
+    "@SELF@" $argv
+  end
+end
+
 function __shadowenv_hook --on-event fish_prompt --on-variable PWD
   @SELF@ hook --fish "$__shadowenv_data" \
     | while read line

--- a/sh/shadowenv.zsh.in
+++ b/sh/shadowenv.zsh.in
@@ -1,3 +1,7 @@
+shadowenv() {
+  [[ "$1" == "diff" ]] && "@SELF@" "$@" "${__shadowenv_data:-}" || "@SELF@" "$@"
+}
+
 __shadowenv_hook() {
   local flags; flags=()
   if [[ "$1" == "zsh-preexec" ]]; then

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,101 @@
+use crate::undo;
+
+use std::collections::HashMap;
+use std::env;
+
+/// print a diff of the env
+pub fn run(verbose: bool, color: bool, shadowenv_data: &str) -> i32 {
+    let mut parts = shadowenv_data.splitn(2, ":");
+    let _prev_hash = parts.next();
+    let json_data = parts.next().unwrap_or("{}");
+    let shadowenv_data = undo::Data::from_str(json_data).unwrap();
+    let mut scalars = HashMap::new();
+    for scalar in shadowenv_data.scalars {
+        scalars.insert(scalar.name.clone(), scalar);
+    }
+    let mut lists = HashMap::new();
+    for list in shadowenv_data.lists {
+        lists.insert(list.name.clone(), list);
+    }
+    for (name, value) in env::vars() {
+        if let Some(scalar) = scalars.remove(&name) {
+            diff_scalar(&scalar, color)
+        } else if let Some(list) = lists.remove(&name) {
+            diff_list(&list, &value, color)
+        } else if verbose {
+            print_verbose(&name, &value)
+        }
+    }
+    for (_name, scalar) in &scalars {
+            diff_scalar(&scalar, color)
+    }
+    for (_name, list) in &lists {
+            diff_list(&list, &"".to_string(), color)
+    }
+    0
+}
+
+fn diff_list(list: &undo::List, current: &str, color: bool) {
+    let formatted_deletions: Vec<String> = if color {
+        list.deletions.iter().map(|x| "\x1b[48;5;52m".to_string() + &x + &"\x1b[0;91m".to_string()).collect()
+    } else {
+        list.deletions.clone()
+    };
+    let mut prefix = formatted_deletions.join(":");
+    let items = current.split(":").collect::<Vec<&str>>();
+    let items = items.into_iter().skip_while(|x| list.additions.contains(&x.to_string()));
+    let items: Vec<&str> = items.collect();
+    let suffix = items.join(":");
+    if suffix != "" && prefix != "" {
+        prefix += ":";
+    }
+    diff_remove(&list.name, &(prefix + &suffix), color);
+    
+    let items = current.split(":").collect::<Vec<&str>>();
+    let items = items.into_iter().map( |x|
+        if list.additions.contains(&x.to_string()) && color {
+            "\x1b[48;5;22m".to_string() + &x + &("\x1b[0;92m".to_string())
+        } else {
+            x.to_string()
+        }
+    );
+    let items: Vec<String> = items.collect();
+    let newline = items.join(":");
+    diff_add(&list.name, &newline, color);
+
+}
+
+fn diff_scalar(scalar: &undo::Scalar, color: bool) {
+    if let Some(value) = &scalar.original {
+        diff_remove(&scalar.name, &value, color);
+    }
+    if let Some(value) = &scalar.current {
+        diff_add(&scalar.name, &value, color);
+    }
+}
+
+fn diff_add(name: &str, value: &str, color: bool) {
+    if color {
+        // Clearing to EOL with \x1b[K prevents a weird issue where a wrapped line uses the last
+        // non-null background color for the newline character, filling the rest of the space in the
+        // line.
+        println!("\x1b[92m+ {}={}\x1b[0m\x1b[K", name, value);
+    } else {
+        println!("+ {}={}", name, value);
+    }
+}
+
+fn diff_remove(name: &str, value: &str, color: bool) {
+    if color {
+        // Clearing to EOL with \x1b[K prevents a weird issue where a wrapped line uses the last
+        // non-null background colour for the newline character, filling the rest of the space in the
+        // line.
+        println!("\x1b[91m- {}={}\x1b[0m\x1b[K", name, value);
+    } else {
+        println!("- {}={}", name, value);
+    }
+}
+
+fn print_verbose(name: &str, value: &str) {
+    println!("  {}={}", name, value)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod features;
 mod hash;
 mod hook;
 mod init;
+mod diff;
 mod lang;
 mod loader;
 mod output;
@@ -73,6 +74,22 @@ fn main() {
                 ),
         )
         .subcommand(
+            SubCommand::with_name("diff")
+                .about("Display a diff of changed environment variables")
+                .arg(
+                    Arg::with_name("verbose")
+                    .long("verbose")
+                    .short("v")
+                    .help("Show all environment variables, not just those that changed"),
+                ).arg(
+                    Arg::with_name("no-color")
+                    .long("no-color")
+                    .short("n")
+                    .help("Do not use color to highlight the diff"),
+                )
+                .arg(Arg::with_name("$__shadowenv_data").required(true)),
+        )
+        .subcommand(
             SubCommand::with_name("trust")
                 .about("Mark this directory as 'trusted', allowing shadowenv programs to be run"),
         )
@@ -114,6 +131,12 @@ fn main() {
                     matches.is_present("silent"),
                 ));
             }
+        }
+        ("diff", Some(matches)) => {
+            let verbose = matches.is_present("verbose");
+            let color = !matches.is_present("no-color");
+            let data = matches.value_of("$__shadowenv_data").unwrap();
+            process::exit(diff::run(verbose, color, data));
         }
         ("trust", Some(_)) => {
             if let Err(err) = trust::run() {


### PR DESCRIPTION
~Must be invoked as `shadowenv diff $__shadowenv_data`, which is a
significant drawback.~

~@burke, was `$__shadowenv_data` left un-exported merely for cleanliness, or do to a security concern I'm not seeing?  What do you think of exporting it, allowing simply `shadowenv diff`?~

Added a shell function to add in `$__shadowenv_data`.

Closes #17