### PR TITLE
Handle unset and empty properly.

### DIFF
--- a/src/shadowenv.rs
+++ b/src/shadowenv.rs
@@ -212,8 +212,11 @@ fn env_remove_from_pathlist_containing(
 }
 
 fn env_append_to_pathlist(env: &mut RefMut<HashMap<String, String>>, a: String, b: String) -> () {
-    let curr = env.get(&a).cloned().unwrap_or("".to_string());
-    let mut items = curr.split(":").collect::<Vec<&str>>();
+    let curr = env.get(&a);
+    let mut items = match curr {
+        Some(existing) => existing.split(":").collect::<Vec<&str>>(),
+        None => vec![],
+    };
     items.insert(items.len(), &b);
     let next = items.join(":");
     env.insert(a, next.to_string());
@@ -221,8 +224,11 @@ fn env_append_to_pathlist(env: &mut RefMut<HashMap<String, String>>, a: String, 
 }
 
 fn env_prepend_to_pathlist(env: &mut RefMut<HashMap<String, String>>, a: String, b: String) -> () {
-    let curr = env.get(&a).cloned().unwrap_or("".to_string());
-    let mut items = curr.split(":").collect::<Vec<&str>>();
+    let curr = env.get(&a);
+    let mut items = match curr {
+        Some(existing) => existing.split(":").collect::<Vec<&str>>(),
+        None => vec![],
+    };
     items.insert(0, &b);
     let next = items.join(":");
     env.insert(a, next.to_string());


### PR DESCRIPTION
The list of items in the path list was improperly being set to a list containing empty string (`[""]`) regardless of whether or not the path list was previously set. This change fixes the handling of unset path lists.

Before:

```
nil        =>  [""]
""         =>  [""]
"foo:bar"  =>  ["foo", "bar"]
```

After:

```
nil        =>  []
""         =>  [""]
"foo:bar"  =>  ["foo", "bar"]
```
Fixes https://github.com/Shopify/shadowenv/issues/37