### PR TITLE
Improving error message when copying/moving projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,17 +398,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "maplit"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
@@ -1164,8 +1164,8 @@ dependencies = [
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2abb5810ef55bb5f5f33b010cc280b3ab877764c902681efc7c8c95628004c"
-"checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum mortal 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "26153280e6a955881f761354b130aa7838f9983836f3de438ac0a8f22cfab1ff"
 "checksum nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d95c5fa8b641c10ad0b8887454ebaafa3c92b5cd5350f8fc693adafd178e7b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +401,14 @@ dependencies = [
 name = "maplit"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "memchr"
@@ -560,6 +577,27 @@ version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quickcheck"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -829,6 +867,8 @@ dependencies = [
  "ketos_derive 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1103,6 +1143,7 @@ dependencies = [
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a"
 "checksum ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81956bcf7ef761fb4e1d88de3fa181358a0d26cbcb9755b587a08f9119824b86"
+"checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum exec 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615"
@@ -1124,6 +1165,7 @@ dependencies = [
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2abb5810ef55bb5f5f33b010cc280b3ab877764c902681efc7c8c95628004c"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
+"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum mortal 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "26153280e6a955881f761354b130aa7838f9983836f3de438ac0a8f22cfab1ff"
 "checksum nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d95c5fa8b641c10ad0b8887454ebaafa3c92b5cd5350f8fc693adafd178e7b"
@@ -1143,6 +1185,8 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9c35d9c36a562f37eca96e79f66d5fd56eefbc22560dacc4a864cabd2d277456"
+"checksum quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7dfc1c4a1e048f5cc7d36a4c4118dfcf31d217c79f4b9a61bad65d68185752c"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,8 @@ serde_json = "1.0.40"
 shell-escape = "0.1.4"
 signatory = "0.11.0"
 signatory-dalek = "0.11.0"
-<<<<<<< HEAD
 maplit = "1.0.1"
-=======
 
 [dev-dependencies]
 quickcheck = "0.8.5"
 quickcheck_macros = "0.8.0"
->>>>>>> Introducting Quickcheck

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,11 @@ serde_json = "1.0.40"
 shell-escape = "0.1.4"
 signatory = "0.11.0"
 signatory-dalek = "0.11.0"
+<<<<<<< HEAD
 maplit = "1.0.1"
+=======
+
+[dev-dependencies]
+quickcheck = "0.8.5"
+quickcheck_macros = "0.8.0"
+>>>>>>> Introducting Quickcheck

--- a/dev.yml
+++ b/dev.yml
@@ -8,3 +8,4 @@ commands:
   test:      cargo test
   run-built: target/debug/shadowenv
   add-man:   cp -r man/* /usr/local/share/man
+  style:     cargo fmt --all -- --check

--- a/sh/shadowenv.bash.in
+++ b/sh/shadowenv.bash.in
@@ -4,7 +4,7 @@ shadowenv() {
 
 __shadowenv_hook() {
   local flags; flags=(--shellpid "$$")
-  if [[ "$1" == "bash-debug" ]]; then
+  if [[ "$1" == "preexec" ]]; then
     flags+=(--silent)
   fi
   # We can't do the nice `x | source /dev/stdin` trick in old versions of bash,

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -81,11 +81,22 @@ impl ToString for Hash {
     }
 }
 
-#[test]
-fn test_key_encoding() {
-    let key = Hash { hash: 2 };
-    let hex = key.to_string();
-    assert_eq!("0000000000000002", hex);
-    let key2: Hash = Hash::from_str(&hex).unwrap();
-    assert_eq!(key, key2);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_key_encoding() {
+        let key = Hash { hash: 2 };
+        let hex = key.to_string();
+        assert_eq!("0000000000000002", hex);
+        let key2: Hash = Hash::from_str(&hex).unwrap();
+        assert_eq!(key, key2);
+    }
+
+    #[quickcheck]
+    fn hash_roundtrip(key: u64) -> bool {
+        let hash = Hash { hash: key };
+        key == Hash::from_str(&hash.to_string()).unwrap().hash
+    }
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -98,7 +98,9 @@ mod tests {
 
     impl Arbitrary for Hash {
         fn arbitrary<G: Gen>(g: &mut G) -> Hash {
-            Hash { hash: Arbitrary::arbitrary(g) }
+            Hash {
+                hash: Arbitrary::arbitrary(g),
+            }
         }
     }
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -22,7 +22,7 @@ pub struct Source {
     pub files: Vec<SourceFile>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Hash {
     pub hash: u64,
 }
@@ -84,6 +84,8 @@ impl ToString for Hash {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use quickcheck::Arbitrary;
+    use quickcheck::Gen;
 
     #[test]
     fn test_key_encoding() {
@@ -94,9 +96,14 @@ mod tests {
         assert_eq!(key, key2);
     }
 
+    impl Arbitrary for Hash {
+        fn arbitrary<G: Gen>(g: &mut G) -> Hash {
+            Hash { hash: Arbitrary::arbitrary(g) }
+        }
+    }
+
     #[quickcheck]
-    fn hash_roundtrip(key: u64) -> bool {
-        let hash = Hash { hash: key };
-        key == Hash::from_str(&hash.to_string()).unwrap().hash
+    fn hash_roundtrip(hash: Hash) -> bool {
+        hash.hash == Hash::from_str(&hash.to_string()).unwrap().hash
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,12 @@ extern crate signatory_dalek;
 #[macro_use]
 extern crate maplit;
 
+#[cfg(test)]
+extern crate quickcheck;
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
+
 mod diff;
 mod execcmd;
 mod features;

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,7 @@ fn main() {
         .subcommand(
             SubCommand::with_name("hook")
                 .about("Runs the shell hook. You shouldn't need to run this manually.")
+                .setting(AppSettings::DisableHelpSubcommand)
                 .arg(Arg::with_name("$__shadowenv_data").required(true))
                 .arg(
                     Arg::with_name("fish")
@@ -101,7 +102,8 @@ fn main() {
         )
         .subcommand(
             SubCommand::with_name("diff")
-                .about("Display a diff of changed environment variables")
+                .about("Display a diff of changed environment variables.")
+                .setting(AppSettings::DisableHelpSubcommand)
                 .arg(
                     Arg::with_name("verbose")
                         .long("verbose")
@@ -118,13 +120,15 @@ fn main() {
         )
         .subcommand(
             SubCommand::with_name("trust")
-                .about("Mark this directory as 'trusted', allowing shadowenv programs to be run"),
+                .about("Mark this directory as 'trusted', allowing shadowenv programs to be run.")
+                .setting(AppSettings::DisableHelpSubcommand)
         )
         .subcommand(
             SubCommand::with_name("exec")
                 .about(
                     "Execute a command after loading the environment from the current directory.",
                 )
+                .setting(AppSettings::DisableHelpSubcommand)
                 .arg(
                     Arg::with_name("$__shadowenv_data")
                         .long("shadowenv-data")
@@ -150,8 +154,9 @@ fn main() {
         )
         .subcommand(
             SubCommand::with_name("init")
-                .about("Prints a script which can be eval'd to set up shadowenv in various shells")
+                .about("Prints a script which can be eval'd to set up shadowenv in various shells.")
                 .setting(AppSettings::SubcommandRequiredElseHelp)
+                .setting(AppSettings::DisableHelpSubcommand)
                 .subcommand(
                     SubCommand::with_name("bash")
                         .about("Prints a script which can be eval'd by bash to set up shadowenv."),
@@ -163,7 +168,7 @@ fn main() {
                 .subcommand(
                     SubCommand::with_name("fish")
                         .about("Prints a script which can be eval'd by fish to set up shadowenv."),
-                ),
+                )
         )
         .get_matches();
 

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -47,8 +47,7 @@ pub fn is_dir_trusted(dir: &PathBuf) -> Result<bool, Error> {
         Some(bytes) => {
             let sig = Ed25519Signature::new(from_vec(bytes));
             let verifier = Ed25519Verifier::from(&pubkey);
-            ed25519::verify(&verifier, msg, &sig)?;
-            Ok(true)
+            Ok(ed25519::verify(&verifier, msg, &sig).is_ok())
         }
     }
 }


### PR DESCRIPTION
Improving error message when copying/moving projects.

- `is_dir_trusted` does not blindly returns verifier errors, it now returns false
- fix to `shadowenv.bash.in` to pass `--silent` on `preexec` to avoid raising errors on `preexec` hooks

This fixes issue #30:

    ~/src/github.com/Shopify $ cp -a dev bar
    ~/src/github.com/Shopify $ cd bar
    shadowenv failure: directory contains untrusted shadowenv program: shadowenv help trust to learn more.
    ~/src/github.com/Shopify/bar $ shadowenv trust
    activated shadowenv (ruby:2.3.7)
    ~/src/github.com/Shopify/bar $

This PR also adds quickcheck tests for `Hash`.