### PR TITLE
Pin nightly to 2019-10-04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
         os: [macOS-10.14, ubuntu-18.04]
 
     steps:
-    - uses: hecrj/setup-rust-action@v1.0.2
+    - uses: hecrj/setup-rust-action@v1.2.0
     - uses: actions/checkout@v1
     - name: Build
       run: cargo build --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
         rust: [stable, beta, nightly]
 
     steps:
-    - uses: hecrj/setup-rust-action@v1.0.2
+    - uses: hecrj/setup-rust-action@v1.2.0
       with:
         rust-version: ${{ matrix.rust }}
         components: rustfmt  # Comma-separated

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly]
+        # Pin temporarily because rustfmt is not available in nightly
+        rust: [stable, beta, nightly-2019-10-04]
 
     steps:
     - uses: hecrj/setup-rust-action@v1.2.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,9 +14,8 @@ jobs:
     - uses: hecrj/setup-rust-action@v1.0.2
       with:
         rust-version: ${{ matrix.rust }}
+        components: rustfmt  # Comma-separated
     - uses: actions/checkout@v1
-    - name: Install rustfmt
-      run: rustup component add rustfmt
     - name: fmt check
       run: cargo fmt --all -- --check
     - name: Build


### PR DESCRIPTION
Use the components config from the rust action

Fixes:
```
error: component 'rustfmt' for target 'x86_64-unknown-linux-gnu' is unavailable for download for channel 'nightly'
```

I left https://github.com/Shopify/shadowenv/issues/59 open for future reference