### PR TITLE
Implement `shadowenv exec --dir <dir>`:

### DIFF
--- a/src/execcmd.rs
+++ b/src/execcmd.rs
@@ -1,12 +1,14 @@
 use crate::hook;
 use failure::Error;
+use std::path::PathBuf;
 use std::vec::Vec;
 
 /// Execute the provided command (argv) after loading the environment from the current directory
 /// (with respect to the optional $__shadowenv_data (`data`)).
-pub fn run(data: Option<&str>, argv: Vec<&str>) -> Result<(), Error> {
+pub fn run(pathbuf: PathBuf, data: Option<&str>, argv: Vec<&str>) -> Result<(), Error> {
     let shadowenv_data = data.unwrap_or("");
-    match hook::load_env(shadowenv_data)? {
+
+    match hook::load_env(pathbuf, shadowenv_data)? {
         Some((shadowenv, _)) => {
             hook::mutate_own_env(&shadowenv)?;
         }


### PR DESCRIPTION
This causes shadowenv exec to load the shadowenv from a given directory,
rather than the current directory, but still execute the command
provided from the current directory after loading that other
environment.

I've also removed the short form (-d) for shadowenv exec
--shadowenv-data, since it just became very confusing. I don't think
anyone was really using that, so removing it should be ok.