### PR TITLE
Export __shadowenv_data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,11 +413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,7 +868,6 @@ dependencies = [
  "ketos 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ketos_derive 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1194,7 +1188,6 @@ dependencies = [
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum linefeed 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2abb5810ef55bb5f5f33b010cc280b3ab877764c902681efc7c8c95628004c"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum mortal 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "26153280e6a955881f761354b130aa7838f9983836f3de438ac0a8f22cfab1ff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ shell-escape = "0.1.4"
 shellexpand = "1.0.0"
 signatory = "0.11.0"
 signatory-dalek = "0.11.0"
-maplit = "1.0.1"
 
 [dev-dependencies]
 quickcheck = "0.8.5"

--- a/man/man1/shadowenv.1
+++ b/man/man1/shadowenv.1
@@ -17,7 +17,7 @@ Do not use color to highlight the diff
 \fB\-v\fR, \fB\-\-verbose\fR
 Show all environment variables as context to the diff
 
-.SS \fBhook\fR [FLAGS] [OPTIONS] \fB$__shadowenv_data\fR
+.SS \fBhook\fR [FLAGS] [OPTIONS]
 Runs the shell hook. You shouldn't need to run this manually; instead, source the output of \fBshadowenv init\fR to create the shell hooks that will use this command.
 
 .TP
@@ -35,10 +35,6 @@ Suppress error printing
 .TP
 \fB\-\-shellpid\fR \fIpid\fR
 Rather than looking up the PPID, use this as the shell's pid
-
-.TP
-\fB$__shadowenv_data\fR
-The contents of the \fB$__shadowenv_data\fR environment variable
 
 .SS \fBinit\fR \fIshell\fR
 Prints a script which can be eval'd to set up shadowenv in various shells

--- a/sh/shadowenv.bash.in
+++ b/sh/shadowenv.bash.in
@@ -1,7 +1,3 @@
-shadowenv() {
-  [[ "$1" == "diff" ]] && "@SELF@" "$@" "${__shadowenv_data:-}" || "@SELF@" "$@"
-}
-
 __shadowenv_hook() {
   local flags; flags=(--shellpid "$$")
   if [[ "$1" == "preexec" ]]; then
@@ -9,7 +5,7 @@ __shadowenv_hook() {
   fi
   # We can't do the nice `x | source /dev/stdin` trick in old versions of bash,
   # meaning we need a subshell, so we can't just let shadowenv look up its ppid.
-  eval "$("@SELF@" hook "${flags[@]}" "${__shadowenv_data:-}")"
+  eval "$("@SELF@" hook "${flags[@]}")"
 }
 
 @HOOKBOOK@

--- a/sh/shadowenv.fish.in
+++ b/sh/shadowenv.fish.in
@@ -1,13 +1,5 @@
-function shadowenv
-  if test "$argv[1]" = "diff"
-    "@SELF@" $argv "$__shadowenv_data"
-  else
-    "@SELF@" $argv
-  end
-end
-
 function __shadowenv_hook --on-event fish_prompt --on-variable PWD
-  @SELF@ hook --fish "$__shadowenv_data" \
+  @SELF@ hook --fish \
     | while read line
       eval "$line" 2>/dev/null
     end

--- a/sh/shadowenv.zsh.in
+++ b/sh/shadowenv.zsh.in
@@ -1,13 +1,9 @@
-shadowenv() {
-  [[ "$1" == "diff" ]] && "@SELF@" "$@" "${__shadowenv_data:-}" || "@SELF@" "$@"
-}
-
 __shadowenv_hook() {
   local flags; flags=()
   if [[ "$1" == "zsh-preexec" ]]; then
     flags=(--silent)
   fi
-  "@SELF@" hook "${flags[@]}" "${__shadowenv_data:-}" | source /dev/stdin
+  "@SELF@" hook "${flags[@]}" | source /dev/stdin
 }
 
 @HOOKBOOK@

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::env;
 
 /// print a diff of the env
-pub fn run(verbose: bool, color: bool, shadowenv_data: &str) -> i32 {
+pub fn run(verbose: bool, color: bool, shadowenv_data: String) -> i32 {
     let mut parts = shadowenv_data.splitn(2, ":");
     let _prev_hash = parts.next();
     let json_data = parts.next().unwrap_or("{}");

--- a/src/execcmd.rs
+++ b/src/execcmd.rs
@@ -4,10 +4,7 @@ use std::path::PathBuf;
 use std::vec::Vec;
 
 /// Execute the provided command (argv) after loading the environment from the current directory
-/// (with respect to the optional $__shadowenv_data (`data`)).
-pub fn run(pathbuf: PathBuf, data: Option<&str>, argv: Vec<&str>) -> Result<(), Error> {
-    let shadowenv_data = data.unwrap_or("");
-
+pub fn run(pathbuf: PathBuf, shadowenv_data: String, argv: Vec<&str>) -> Result<(), Error> {
     match hook::load_env(pathbuf, shadowenv_data)? {
         Some((shadowenv, _)) => {
             hook::mutate_own_env(&shadowenv)?;


### PR DESCRIPTION
Not exporting `__shadowenv_data` can cause problems when the user uses tmux, among probably other issues. This was a bad idea from the start.

This will be a 2.0.0 release