### PR TITLE
Force hook on first run

### DIFF
--- a/sh/shadowenv.bash.in
+++ b/sh/shadowenv.bash.in
@@ -3,9 +3,13 @@ __shadowenv_hook() {
   if [[ "$1" == "preexec" ]]; then
     flags+=(--silent)
   fi
+  if [[ ! -v __shadowenv_first_run ]]; then
+    flags+=(--force)
+  fi
   # We can't do the nice `x | source /dev/stdin` trick in old versions of bash,
   # meaning we need a subshell, so we can't just let shadowenv look up its ppid.
   eval "$("@SELF@" hook "${flags[@]}")"
+  __shadowenv_first_run=1
 }
 
 @HOOKBOOK@

--- a/sh/shadowenv.bash.in
+++ b/sh/shadowenv.bash.in
@@ -3,14 +3,16 @@ __shadowenv_hook() {
   if [[ "$1" == "preexec" ]]; then
     flags+=(--silent)
   fi
-  if [[ ! -v __shadowenv_first_run ]]; then
+  if [[ -n $__shadowenv_force_run ]]; then
     flags+=(--force)
+    unset __shadowenv_force_run
   fi
   # We can't do the nice `x | source /dev/stdin` trick in old versions of bash,
   # meaning we need a subshell, so we can't just let shadowenv look up its ppid.
   eval "$("@SELF@" hook "${flags[@]}")"
-  __shadowenv_first_run=1
 }
 
 @HOOKBOOK@
+
+__shadowenv_force_run=1
 hookbook_add_hook __shadowenv_hook

--- a/sh/shadowenv.fish.in
+++ b/sh/shadowenv.fish.in
@@ -1,6 +1,13 @@
 function __shadowenv_hook --on-event fish_prompt --on-variable PWD
-  @SELF@ hook --fish \
+  set -l flags --fish
+  if [ -n "$__shadowenv_force_run" ];
+    set -a flags --force
+    set -eg __shadowenv_force_run
+  end
+  @SELF@ hook $flags \
     | while read line
       eval "$line" 2>/dev/null
     end
 end
+
+set -g __shadowenv_force_run 1

--- a/sh/shadowenv.zsh.in
+++ b/sh/shadowenv.zsh.in
@@ -3,12 +3,14 @@ __shadowenv_hook() {
   if [[ "$1" == "zsh-preexec" ]]; then
     flags=(--silent)
   fi
-  if [[ ! -v __shadowenv_first_run ]]; then
+  if [[ -n $__shadowenv_force_run ]]; then
     flags+=(--force)
+    unset __shadowenv_force_run
   fi
   "@SELF@" hook "${flags[@]}" | source /dev/stdin
-  __shadowenv_first_run=1
 }
 
 @HOOKBOOK@
+
+__shadowenv_force_run=1
 hookbook_add_hook __shadowenv_hook

--- a/sh/shadowenv.zsh.in
+++ b/sh/shadowenv.zsh.in
@@ -3,7 +3,11 @@ __shadowenv_hook() {
   if [[ "$1" == "zsh-preexec" ]]; then
     flags=(--silent)
   fi
+  if [[ ! -v __shadowenv_first_run ]]; then
+    flags+=(--force)
+  fi
   "@SELF@" hook "${flags[@]}" | source /dev/stdin
+  __shadowenv_first_run=1
 }
 
 @HOOKBOOK@

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,11 @@ pub fn app() -> App<'static, 'static> {
                         .help("Format variable assignments for posix shells (default)"),
                 )
                 .arg(
+                    Arg::with_name("force")
+                        .long("force")
+                        .help("USE THE FORCE"),
+                )
+                .arg(
                     Arg::with_name("silent")
                         .long("silent")
                         .help("Suppress error printing"),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,7 @@ pub fn app() -> App<'static, 'static> {
                 .arg(
                     Arg::with_name("force")
                         .long("force")
-                        .help("USE THE FORCE"),
+                        .help("Force the shadowenv to be applied, even if the working directory has not changed."),
                 )
                 .arg(
                     Arg::with_name("silent")

--- a/src/execcmd.rs
+++ b/src/execcmd.rs
@@ -5,7 +5,7 @@ use std::vec::Vec;
 
 /// Execute the provided command (argv) after loading the environment from the current directory
 pub fn run(pathbuf: PathBuf, shadowenv_data: String, argv: Vec<&str>) -> Result<(), Error> {
-    match hook::load_env(pathbuf, shadowenv_data)? {
+    match hook::load_env(pathbuf, shadowenv_data, false)? {
         Some((shadowenv, _)) => {
             hook::mutate_own_env(&shadowenv)?;
         }

--- a/src/execcmd.rs
+++ b/src/execcmd.rs
@@ -5,7 +5,7 @@ use std::vec::Vec;
 
 /// Execute the provided command (argv) after loading the environment from the current directory
 pub fn run(pathbuf: PathBuf, shadowenv_data: String, argv: Vec<&str>) -> Result<(), Error> {
-    match hook::load_env(pathbuf, shadowenv_data, false)? {
+    match hook::load_env(pathbuf, shadowenv_data, true)? {
         Some((shadowenv, _)) => {
             hook::mutate_own_env(&shadowenv)?;
         }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -48,8 +48,9 @@ pub fn run(
     pathbuf: PathBuf,
     shadowenv_data: String,
     mode: VariableOutputMode,
+    force: bool,
 ) -> Result<(), Error> {
-    match load_env(pathbuf, shadowenv_data)? {
+    match load_env(pathbuf, shadowenv_data, force)? {
         Some((shadowenv, activation)) => {
             apply_env(&shadowenv, mode, activation)?;
             Ok(())
@@ -61,6 +62,7 @@ pub fn run(
 pub fn load_env(
     pathbuf: PathBuf,
     shadowenv_data: String,
+    force: bool,
 ) -> Result<Option<(Shadowenv, bool)>, Error> {
     let mut parts = shadowenv_data.splitn(2, ":");
     let prev_hash = parts.next();
@@ -79,7 +81,7 @@ pub fn load_env(
         (None, None) => {
             return Ok(None);
         }
-        (Some(a), Some(t)) if a.hash == t.hash()? => {
+        (Some(a), Some(t)) if a.hash == t.hash()? && !force => {
             return Ok(None);
         }
         (_, _) => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ fn main() {
             let legacy_fallback_data = matches.value_of("$__shadowenv_data").map(|d| d.to_string());
             let data = Shadowenv::load_shadowenv_data_or_legacy_fallback(legacy_fallback_data);
             let shellpid = determine_shellpid_or_crash(matches.value_of("shellpid"));
+            let force = matches.is_present("force");
 
             let mode = match true {
                 true if matches.is_present("porcelain") => VariableOutputMode::PorcelainMode,
@@ -64,7 +65,7 @@ fn main() {
                 true if matches.is_present("pretty-json") => VariableOutputMode::PrettyJsonMode,
                 _ => VariableOutputMode::PosixMode,
             };
-            if let Err(err) = hook::run(current_dir, data, mode) {
+            if let Err(err) = hook::run(current_dir, data, mode, force) {
                 process::exit(output::handle_hook_error(
                     err,
                     shellpid,


### PR DESCRIPTION
There are scenarios where the shadowenv's exported environment is carried forward to a new shell as expected but is modified by the new shell's initialization. In this case shadowenv would not update the environment since the working directory hasn't changed from the previous shell.

The example below shows what happens when the user defines a default ruby in their bashrc.

```
$ cat ~/.bashrc
chruby 2.7.0

$ dev cd web
activated shadowenv (node:v10.18.0, ruby:2.6.5)

$ ruby --version
ruby 2.6.5

$ bash -l

$ ruby --version
ruby 2.7.0
```

Some affected scenarios that I know of include:

- Starting a new shell from a project directory (as exampled above)
- Starting tmux from a project directory
- Starting an editor (vscode, vim...) from a project directory and using its built-in terminal

To address the issue this PR updates the shell hook functions to set an _unexported_ variable named `$__shadowenv_first_run`. The hook will look for the variable and if it's not defined, which it wont be in a new shell because it is unexported, it would mean that it is the first run of the hook and it will pass the new `--force` flag to the `shadowenv hook` command. The `--force` flag instructs shadowenv always apply the new environment regardless of whether the working directory changed.

Fixes https://github.com/Shopify/vscode-shadowenv/issues/4

Also seen on [discourse](https://discourse.shopify.io/t/shadowenv-not-being-activated-unless-directory-is-explicitly-cdd-into/8478/3) 