### PR TITLE
Fix trust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "shadowenv"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "atty",
  "blake2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shadowenv"
-version = "2.0.4"
+version = "2.0.5"
 authors = ["Burke Libbey <burke@libbey.me>", "Lisa Ugray <lisa.ugray@shopify.com>", "Aaron Olson <aaron.olson@shopify.com>"]
 edition = "2018"
 

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ rustPlatform.buildRustPackage rec {
     (lib.findFirst (line: lib.hasPrefix ''version = "'' line) ''version = ""''
       (lib.splitString "\n" (builtins.readFile (./. + "/Cargo.toml")))));
   src = builtins.fetchGit { url = "file://${builtins.toString ./.}"; };
-  cargoSha256 = "09lyyvcn2x5f386sipimrdkhd2vgysfmh44r2vb3hrbwnscnibsz";
+  cargoSha256 = "1ksrqyb88z0sav0hg2asly5my7zgqvjla22a47wb0sppj9f0z70b";
   nativeBuildInputs = [ installShellFiles ];
   buildInputs =
     lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -52,7 +52,7 @@ pub fn is_dir_trusted(dir: &PathBuf) -> Result<bool, Error> {
 }
 
 fn load_or_generate_signer() -> Result<Keypair, Error> {
-    let path = format!("{}/.config/shadowenv/trust-key", std::env::var("HOME")?);
+    let path = format!("{}/.config/shadowenv/trust-key-v2", std::env::var("HOME")?);
 
     let r_o_bytes: Result<Option<Vec<u8>>, Error> = match fs::read(Path::new(&path)) {
         Ok(bytes) => Ok(Some(bytes)),


### PR DESCRIPTION
On systems that used a pre 2.0.4 version of shadowenv, the trust key would be in a different format that does not work for 2.0.4+. Giving it a v2 file name ensures we don't try to use the old key.