### PR TITLE
Use `macos-11` runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-11, ubuntu-latest]
         target: [x86_64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
         exclude:
         # Don't build linux targets on macos
-        - os: macos-latest
+        - os: macos-11
           target: x86_64-unknown-linux-gnu
         # Don't build darwin targets on ubuntu
         - os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-11, ubuntu-latest]
         target: [x86_64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
         toolchain: [stable, nightly]
         exclude:
         # Don't test linux targets on macos
-        - os: macos-latest
+        - os: macos-11
           target: x86_64-unknown-linux-gnu
         # Don't test darwin targets on ubuntu
         - os: ubuntu-latest


### PR DESCRIPTION
`macos-latest` runs macOS Catalina 10.15 which does not have cross compilation support for `aarch64`