### PR TITLE
Evaluate expand-path in the shadowenv root directory

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -13,6 +13,7 @@ const GROUP_SEPARATOR: &'static str = "\x1D";
 
 #[derive(Debug, Clone)]
 pub struct Source {
+    pub dir: String,
     pub files: Vec<SourceFile>,
 }
 
@@ -50,8 +51,11 @@ pub struct Hash {
 struct WrongInputSize;
 
 impl Source {
-    pub fn new() -> Self {
-        Source { files: vec![] }
+    pub fn new(dir: String) -> Self {
+        Source {
+            dir: dir,
+            files: vec![],
+        }
     }
 
     pub fn add_file(&mut self, name: String, contents: String) -> Result<(), Error> {
@@ -67,6 +71,8 @@ impl Source {
             return Ok(0);
         }
         let mut hasher = VarBlake2b::new(8)?;
+        hasher.input(&self.dir);
+        hasher.input(FILE_SEPARATOR);
         for file in self.files.iter() {
             hasher.input(&file.name);
             hasher.input(GROUP_SEPARATOR);
@@ -117,6 +123,7 @@ mod tests {
     impl Arbitrary for Source {
         fn arbitrary(g: &mut Gen) -> Source {
             Source {
+                dir: Arbitrary::arbitrary(g),
                 files: Arbitrary::arbitrary(g),
             }
         }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -3,7 +3,9 @@ use crate::shadowenv::Shadowenv;
 
 use failure::Fail;
 use ketos::{Error, FromValueRef, Value};
+use std::env;
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
 pub struct ShadowLang {}
@@ -246,6 +248,8 @@ impl ShadowLang {
 
         let mut files = source.files.clone();
         files.sort();
+        let original_path = env::current_dir();
+        let _ = env::set_current_dir(Path::new(&source.dir));
 
         for source_file in &files {
             let fname = format!("__shadowenv__{}", source_file.name);
@@ -273,6 +277,9 @@ impl ShadowLang {
                 }
                 return Err(err);
             };
+        }
+        if let Ok(dir) = original_path {
+            let _ = env::set_current_dir(dir);
         }
 
         Ok(())

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -29,7 +29,7 @@ pub fn find_root(at: PathBuf, relative_component: &str) -> Result<Option<PathBuf
 ///
 /// Note that this function assumes that the dirpath is trusted.
 pub fn load(dirpath: PathBuf) -> Result<Option<Source>, Error> {
-    let mut source = Source::new();
+    let mut source = Source::new(dirpath.parent().unwrap().to_str().unwrap().to_string());
 
     for entry in fs::read_dir(dirpath)? {
         if let Ok(entry) = entry {


### PR DESCRIPTION
with `some_dir/.shadowenv.d/custom.lisp`:
```lisp
(env/set "FOO" (expand-path "./bin"))
```
If you
```
cd some_dir
cd sub_dir
```
Everything worked as expected, since the source hash didn't change on the second cd, leaving the lisp unevaluated. But if instead you went directly
```
cd some_dir/sub_dir
```
Shadowenv would fail, as it would try to set FOO to the non-existant `some_dir/sub_dir/bin` instead of `some_dir/bin`.

So add the root dir to the source hash, since it should effect the results, and then perform the shadowlisp evaluation at the root dir.

Fixes #76.