### PR TITLE
Fish: source the hook code, don't eval line-by-line

### DIFF
--- a/sh/shadowenv.fish.in
+++ b/sh/shadowenv.fish.in
@@ -4,10 +4,7 @@ function __shadowenv_hook --on-event fish_prompt --on-variable PWD
     set -a flags --force
     set -eg __shadowenv_force_run
   end
-  @SELF@ hook $flags \
-    | while read line
-      eval "$line" 2>/dev/null
-    end
+  @SELF@ hook $flags | source 2>/dev/null
 end
 
 set -g __shadowenv_force_run 1


### PR DESCRIPTION
Reading the generated hook code line-by-line, and evaluating each line individually,
doesn't work if a value has linebreaks inside it.

Tested locally with fish version 3.3.1.