### PR TITLE
feat: adds support for xonsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ some limited ability to make the manipulations dynamic.
 
 ![shadowenv in action](https://burkelibbey.s3.amazonaws.com/shadowenv.gif)
 
-In order to use shadowenv, add a line to your shell profile (`.zshrc`, `.bash_profile`, or
-`config.fish`) reading:
+In order to use shadowenv, add a line to your shell profile (`.zshrc`, `.bash_profile`,
+`config.fish`, or `.xonshrc`) reading:
 
 ```bash
-eval "$(shadowenv init bash)" # for bash
-eval "$(shadowenv init zsh)"  # for zsh
-shadowenv init fish | source  # for fish
+eval "$(shadowenv init bash)"  # for bash
+eval "$(shadowenv init zsh)"   # for zsh
+shadowenv init fish | source   # for fish
+execx($(shadowenv init xonsh)) # for xonsh
 ```
 
 With this code loaded, upon entering a directory containing a `.shadowenv.d` directory,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,13 +67,14 @@ cp target/release/shadowenv /usr/local/bin/shadowenv
 </div>
 
 Shadowenv relies on a shell hook to make changes when you change directories. In order to use it,
-add a line to your shell profile (`.zshrc`, `.bash_profile`, or `config.fish`) reading:
+add a line to your shell profile (`.zshrc`, `.bash_profile`, `config.fish`, or `.xonshrc`) reading:
 
 ```bash
 # (only add one of these!)
-eval "$(shadowenv init bash)" # for bash
-eval "$(shadowenv init zsh)"  # for zsh
-shadowenv init fish | source  # for fish
+eval "$(shadowenv init bash)"  # for bash
+eval "$(shadowenv init zsh)"   # for zsh
+shadowenv init fish | source   # for fish
+execx($(shadowenv init xonsh)) # for xonsh
 ```
 
 Make sure to restart your shell after adding this.

--- a/sh/shadowenv.xonsh.in
+++ b/sh/shadowenv.xonsh.in
@@ -1,20 +1,7 @@
-import json
-
-def __shadowenv() -> None:
-    shadow_data = $(@SELF@ hook --json)
-    if shadow_data:
-        envs = json.loads(shadow_data)
-        for shadow_key in ["exported", "unexported"]:
-            for k,v in envs.get(shadow_key, {}).items():
-                if v is None:
-                    del ${k}
-                else:
-                    ${k} = v
-
 @events.on_post_rc
 def __shadowenv_post_rc() -> None:
-    __shadowenv()
+    execx($(@SELF@ hook --xonsh))
 
 @events.on_chdir
 def __shadowenv_chdir(olddir: str, newdir: str) -> None:
-    __shadowenv()
+    execx($(@SELF@ hook --xonsh))

--- a/sh/shadowenv.xonsh.in
+++ b/sh/shadowenv.xonsh.in
@@ -1,21 +1,20 @@
 import json
 
 def __shadowenv() -> None:
-  shadow_data = $(@SELF@ hook --json)
-  if shadow_data:
-    envs = json.loads(shadow_data)
-    for shadow_key in ["exported", "unexported"]:
-      for k,v in envs.get(shadow_key, {}).items():
-        if v is None:
-          del ${k}
-        else:
-          ${k} = v
-
+    shadow_data = $(@SELF@ hook --json)
+    if shadow_data:
+        envs = json.loads(shadow_data)
+        for shadow_key in ["exported", "unexported"]:
+            for k,v in envs.get(shadow_key, {}).items():
+                if v is None:
+                    del ${k}
+                else:
+                    ${k} = v
 
 @events.on_post_rc
 def __shadowenv_post_rc() -> None:
-  __shadowenv()
+    __shadowenv()
 
 @events.on_chdir
 def __shadowenv_chdir(olddir: str, newdir: str) -> None:
-  __shadowenv()
+    __shadowenv()

--- a/sh/shadowenv.xonsh.in
+++ b/sh/shadowenv.xonsh.in
@@ -3,12 +3,14 @@ import json
 def __shadowenv() -> None:
   shadow_data = $(@SELF@ hook --json)
   if shadow_data:
-      envs = json.loads(shadow_data)
-      for k,v in envs.get("exported").items():
+    envs = json.loads(shadow_data)
+    for shadow_key in ["exported", "unexported"]:
+      for k,v in envs.get(shadow_key, {}).items():
         if v is None:
-            del ${k}
+          del ${k}
         else:
-            ${k} = v
+          ${k} = v
+
 
 @events.on_post_rc
 def __shadowenv_post_rc() -> None:

--- a/sh/shadowenv.xonsh.in
+++ b/sh/shadowenv.xonsh.in
@@ -1,0 +1,19 @@
+import json
+
+def __shadowenv() -> None:
+  shadow_data = $(@SELF@ hook --json)
+  if shadow_data:
+      envs = json.loads(shadow_data)
+      for k,v in envs.get("exported").items():
+        if v is None:
+            del ${k}
+        else:
+            ${k} = v
+
+@events.on_post_rc
+def __shadowenv_post_rc() -> None:
+  __shadowenv()
+
+@events.on_chdir
+def __shadowenv_chdir(olddir: str, newdir: str) -> None:
+  __shadowenv()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,5 +147,9 @@ pub fn app() -> App<'static, 'static> {
                     SubCommand::with_name("fish")
                         .about("Prints a script which can be eval'd by fish to set up shadowenv."),
                 )
+                .subcommand(
+                    SubCommand::with_name("xonsh")
+                        .about("Prints a script which can be eval'd by xonsh to set up shadowenv."),
+                )
         )
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,11 @@ pub fn app() -> App<'static, 'static> {
                         .help("Format variable assignments for fish shell"),
                 )
                 .arg(
+                    Arg::with_name("xonsh")
+                        .long("xonsh")
+                        .help("Format variable assignments for xonsh shell"),
+                )
+                .arg(
                     Arg::with_name("posix")
                         .long("posix")
                         .help("Format variable assignments for posix shells (default)"),
@@ -66,7 +71,7 @@ pub fn app() -> App<'static, 'static> {
                         .long("pretty-json")
                         .help("Format variable assignments as pretty JSON"),
                 )
-                .group(ArgGroup::with_name("format").args(&["porcelain", "posix", "fish", "json", "pretty-json"])),
+                .group(ArgGroup::with_name("format").args(&["porcelain", "posix", "fish", "xonsh", "json", "pretty-json"])),
         )
         .subcommand(
             SubCommand::with_name("diff")

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -24,6 +24,7 @@ pub enum VariableOutputMode {
     PosixMode,
     JsonMode,
     PrettyJsonMode,
+    XonshMode,
 }
 
 #[derive(Serialize, Debug)]
@@ -164,6 +165,14 @@ pub fn apply_env(
                 }
             }
             output::print_activation_to_tty(activation, shadowenv.features());
+        }
+        VariableOutputMode::XonshMode => {
+            for (k, v) in shadowenv.exports()? {
+                match v {
+                    Some(s) => println!(r#"${} = "{}""#, k, s.replace(r#"""#, r#"\""#)),
+                    None => println!("del ${}", k),
+                }
+            }
         }
         VariableOutputMode::PorcelainMode => {
             // three fields: <operation> : <name> : <value>

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -169,7 +169,7 @@ pub fn apply_env(
         VariableOutputMode::XonshMode => {
             for (k, v) in shadowenv.exports()? {
                 match v {
-                    Some(s) => println!(r#"${} = "{}""#, k, s.replace(r#"""#, r#"\""#)),
+                    Some(s) => println!(r#"${} = "{}""#, k, s.escape_default()),
                     None => println!("del ${}", k),
                 }
             }

--- a/src/init.rs
+++ b/src/init.rs
@@ -8,9 +8,10 @@ pub fn run(shellname: &str) -> i32 {
         "bash" => print_script(pb, include_bytes!("../sh/shadowenv.bash.in")),
         "zsh" => print_script(pb, include_bytes!("../sh/shadowenv.zsh.in")),
         "fish" => print_script(pb, include_bytes!("../sh/shadowenv.fish.in")),
+        "xonsh" => print_script(pb, include_bytes!("../sh/shadowenv.xonsh.in")),
         _ => {
             eprintln!(
-                "invalid shell name '{}' (must be one of bash, zsh, fish)",
+                "invalid shell name '{}' (must be one of bash, zsh, fish, xonsh)",
                 shellname
             );
             1

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ fn main() {
             let mode = match true {
                 true if matches.is_present("porcelain") => VariableOutputMode::PorcelainMode,
                 true if matches.is_present("fish") => VariableOutputMode::FishMode,
+                true if matches.is_present("xonsh") => VariableOutputMode::XonshMode,
                 true if matches.is_present("json") => VariableOutputMode::JsonMode,
                 true if matches.is_present("pretty-json") => VariableOutputMode::PrettyJsonMode,
                 _ => VariableOutputMode::PosixMode,


### PR DESCRIPTION
## What

Adds another subcommand for `init` that prints out an initialization script for [xonsh](https://xon.sh) which utilizes Xonsh's event decorators to run `shadowenv` when a directory changes, or when a new shell is spawned.

I've tested this locally with my `xonsh` installation. The initialization script can be included in `.xonshrc` with `execx($(shadowenv init xonsh))`
