### PR TITLE
Allow user to turn off "shadowenv [de]activated" prompts

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -2,7 +2,7 @@ use crate::features::Feature;
 use crate::loader;
 use crate::trust;
 
-use atty::{isnt, Stream};
+use atty::{is, Stream};
 use failure::{format_err, Error};
 use regex::Regex;
 use std::collections::HashSet;
@@ -38,7 +38,7 @@ pub fn handle_hook_error(err: Error, shellpid: u32, silent: bool) -> i32 {
 }
 
 pub fn print_activation_to_tty(activated: bool, features: HashSet<Feature>) {
-    if isnt(Stream::Stderr) {
+    if !should_print_activation() {
         return;
     }
     if activated {
@@ -140,4 +140,13 @@ fn create_cooldown_sentinel(path: PathBuf) -> Result<(), Error> {
         .create(true)
         .open(path)?;
     Ok(())
+}
+
+fn should_print_activation() -> bool {
+    let configured_to_print: bool;
+    match env::var("SHADOWENV_SILENT") {
+        Ok(_) => configured_to_print = false,
+        Err(_) => configured_to_print = true,
+    };
+    return is(Stream::Stderr) && configured_to_print;
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -145,7 +145,10 @@ fn create_cooldown_sentinel(path: PathBuf) -> Result<(), Error> {
 fn should_print_activation() -> bool {
     let configured_to_print: bool;
     match env::var("SHADOWENV_SILENT") {
-        Ok(_) => configured_to_print = false,
+        Ok(value) => match value.to_lowercase().as_str() {
+            "0" | "false" | "no" | "" => configured_to_print = true,
+            _ => configured_to_print = false,
+        },
         Err(_) => configured_to_print = true,
     };
     return is(Stream::Stderr) && configured_to_print;


### PR DESCRIPTION
For some people, having output on `cd` commands is a bit noisy.

This turns off the output of the happy path: I can assume that shadowenv did its thing unless it tells me it failed.

Messages about the directory not being trusted are still printed