### PR TITLE
Default `no_clobber` to false

### DIFF
--- a/src/undo.rs
+++ b/src/undo.rs
@@ -10,6 +10,7 @@ pub struct Scalar {
     pub original: Option<String>,
     #[serde(default)]
     pub current: Option<String>,
+    #[serde(default)]
     pub no_clobber: bool,
 }
 


### PR DESCRIPTION
If the `no_clobber` field is not present in the undo data, assume it is false. This may help prevent errors when upgrading shadowenv.