### PR TITLE
Add --no-hookbook flag to init

### DIFF
--- a/sh/shadowenv.bash.in
+++ b/sh/shadowenv.bash.in
@@ -11,8 +11,6 @@ __shadowenv_hook() {
   # meaning we need a subshell, so we can't just let shadowenv look up its ppid.
   eval "$("@SELF@" hook "${flags[@]}")"
 }
-
 @HOOKBOOK@
-
 __shadowenv_force_run=1
 hookbook_add_hook __shadowenv_hook

--- a/sh/shadowenv.zsh.in
+++ b/sh/shadowenv.zsh.in
@@ -9,8 +9,6 @@ __shadowenv_hook() {
   fi
   "@SELF@" hook "${flags[@]}" | source /dev/stdin
 }
-
 @HOOKBOOK@
-
 __shadowenv_force_run=1
 hookbook_add_hook __shadowenv_hook

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,13 +92,21 @@ pub struct TrustCmd {}
 #[clap(disable_help_subcommand = true)]
 pub enum InitCmd {
     /// Prints a script which can be eval'd by bash to set up shadowenv.
-    Bash,
+    Bash(InitOptions),
 
     /// Prints a script which can be eval'd by zsh to set up shadowenv.
-    Zsh,
+    Zsh(InitOptions),
 
     /// Prints a script which can be eval'd by fish to set up shadowenv.
     Fish,
+}
+
+/// Options shared by all init subcommands
+#[derive(Args, Debug)]
+pub struct InitOptions {
+    /// Don't print hookbook inline (it's still required -- only use if you've already loaded it)
+    #[arg(long)]
+    pub no_hookbook: bool,
 }
 
 /// Print a little glyph you can include in a shell prompt to indicate that shadowenv is active.

--- a/src/init.rs
+++ b/src/init.rs
@@ -6,17 +6,38 @@ use std::path::PathBuf;
 pub fn run(cmd: InitCmd) {
     let pb = std::env::current_exe().unwrap(); // this would be... an unusual failure.
     match cmd {
-        Bash => print_script(pb, include_bytes!("../sh/shadowenv.bash.in")),
-        Zsh => print_script(pb, include_bytes!("../sh/shadowenv.zsh.in")),
-        Fish => print_script(pb, include_bytes!("../sh/shadowenv.fish.in")),
+        Bash(opts) => print_script(
+            pb,
+            include_bytes!("../sh/shadowenv.bash.in"),
+            opts.no_hookbook,
+        ),
+        Zsh(opts) => print_script(
+            pb,
+            include_bytes!("../sh/shadowenv.zsh.in"),
+            opts.no_hookbook,
+        ),
+        Fish => print_script(
+            pb,
+            include_bytes!("../sh/shadowenv.fish.in"),
+            true, // Fish doesn't use hookbook
+        ),
     };
 }
 
-fn print_script(selfpath: PathBuf, bytes: &[u8]) -> i32 {
-    let hookbook = String::from_utf8_lossy(include_bytes!("../sh/hookbook.sh"));
+fn print_script(selfpath: PathBuf, bytes: &[u8], no_hookbook: bool) -> i32 {
     let script = String::from_utf8_lossy(bytes);
     let script = script.replace("@SELF@", selfpath.into_os_string().to_str().unwrap());
-    let script = script.replace("@HOOKBOOK@", &hookbook);
-    println!("{}", script);
+
+    if no_hookbook {
+        // If no_hookbook is true, replace @HOOKBOOK@ with an empty string
+        let script = script.replace("@HOOKBOOK@", "");
+        println!("{}", script);
+    } else {
+        // Otherwise, include the hookbook as before, but pad with newlines
+        let hookbook = String::from_utf8_lossy(include_bytes!("../sh/hookbook.sh"));
+        let padded_hookbook = format!("\n{}\n", hookbook);
+        let script = script.replace("@HOOKBOOK@", &padded_hookbook);
+        println!("{}", script);
+    }
     0
 }


### PR DESCRIPTION
I have a use-case where I'd prefer to include hookbook manually.