### PR TITLE
Add support for shadowenv hook --clobber

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,10 @@ pub struct HookCmd {
     #[arg(long)]
     pub shellpid: Option<u32>,
 
+    /// Clobber overridden environment variables when unshadowing.
+    #[arg(long)]
+    pub clobber: bool,
+
     #[command(flatten)]
     pub format: FormatOptions,
 }

--- a/src/exec_cmd.rs
+++ b/src/exec_cmd.rs
@@ -10,7 +10,7 @@ pub fn run(cmd: ExecCmd) -> Result<(), Error> {
         .map(|d| PathBuf::from(d))
         .unwrap_or(get_current_dir_or_exit());
 
-    if let Some(shadowenv) = hook::load_env(pathbuf, data, true)? {
+    if let Some(shadowenv) = hook::load_env(pathbuf, data, true, false)? {
         hook::mutate_own_env(&shadowenv)?;
     }
 

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -334,7 +334,7 @@ mod tests {
             .into_iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect::<HashMap<_, _>>();
-        Shadowenv::new(env, Data::new(), 0)
+        Shadowenv::new(env, Data::new(), 0, false)
     }
 
     #[test]


### PR DESCRIPTION
This is mainly useful in conjunction with --force to allow tools to detect when shadowenv has been overridden, e.g. manually or accidentally when mixing it with other tools like nvm and chruby.