### PR TITLE
Don't explode when expand-path result is missing

### DIFF
--- a/docs/shadowlisp.md
+++ b/docs/shadowlisp.md
@@ -228,8 +228,8 @@ This can be especially useful in the sort of usage shown to the right.
 (expand-path "./bin") ; "/Users/you/src/project/bin"
 ```
 
-`expand-path` resolves a path to a canonicalized path, resolving any symlinks, relative references
-from the present working directory, and `~`.
+`expand-path` resolves a path to a canonicalized path, resolving relative references
+from the present working directory and `~`.
 
 | Argument | Type | Description |
 |---|---|---|

--- a/man/man5/shadowlisp.5
+++ b/man/man5/shadowlisp.5
@@ -147,8 +147,8 @@ It's occasionally useful to take a subdirectory of a path found from some other 
 
 .SS \fB(expand-path \fIpath\fB)\fR
 
-\fBexpand-path\fR resolves a path to a canonicalized path, resolving any symlinks, relative references
-from the present working directory, and \fB~\fR.
+\fBexpand-path\fR resolves a path to a canonicalized path, resolving relative references
+from the present working directory and \fB~\fR.
 
 .TP
 \fBpath\fR

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -6,7 +6,7 @@ use ketos::{Context, Error, FromValueRef, Name, Value};
 use ketos_derive::{ForeignValue, FromValueRef};
 use std::{
     cell::{Ref, RefCell},
-    env, fs,
+    env,
     path::{Path, PathBuf},
     rc::Rc,
 };
@@ -240,7 +240,7 @@ impl ShadowLang {
                 assert_args!(args, 1, name);
                 let path = <&str as FromValueRef>::from_value_ref(&args[0])?;
                 let expanded = shellexpand::tilde(path);
-                let canonicalized = match fs::canonicalize(expanded.to_string()) {
+                let absolutized = match std::path::absolute(expanded.to_string()) {
                     Ok(p) => p,
                     Err(e) => {
                         return Err(From::from(ketos::io::IoError {
@@ -251,7 +251,7 @@ impl ShadowLang {
                     }
                 };
                 Ok(<String as Into<Value>>::into(
-                    canonicalized.to_string_lossy().to_string(),
+                    absolutized.to_string_lossy().to_string(),
                 ))
             })
         });


### PR DESCRIPTION
Expressions like (expand-path "~/does-not-exist") explode since
std::fs::canonicalize needs to point to a file that exists. In the vast
majority of cases this isn't desirable, nor is its behaviour of
resolving symlinks. Symlinks subtly break shadowenv's eval caching
mechanism because the value does not get updated if the symlink changes,
and shadowenv explodes if the there is a symlink loop. If people want
that behaviour for some reason I think we should expose it via a
different expression, or ideally people should canonicalize the paths
externally.