### PR TITLE
Update documentation for `shadowenv exec`

### DIFF
--- a/man/man1/shadowenv.1
+++ b/man/man1/shadowenv.1
@@ -1,6 +1,6 @@
 .TH SHADOWENV 1
 .SH NAME
-shadowenv \- maninpulate environment variables as you change directories
+shadowenv \- manipulate environment variables as you change directories
 .SH SYNOPSIS
 \fBshadowenv\fR [\fB\-h\fR|\fB\-V\fR] \fIsubcommand\fR
 .SH DESCRIPTION
@@ -26,11 +26,11 @@ Instead of searching from the current directory for a .shadowenv.d, search from 
 
 .TP
 \fBchild-argv0\fR
-If the command doesn't need arguments, it can be passed directly as the last arugment.
+If the command doesn't need arguments, it can be passed directly as the last argument.
 
 .TP
 \fBchild-argv...\fR
-If the command requires arguments, they must all be passed after a '--'.
+If the command requires arguments, the command and all arguments must be passed after a '--'.
 
 .SS \fBhook\fR [FLAGS] [OPTIONS]
 Runs the shell hook. You shouldn't need to run this manually; instead, source the output of \fBshadowenv init\fR to create the shell hooks that will use this command.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,10 +20,10 @@ pub struct ExecCmd {
     #[arg(long)]
     pub dir: Option<String>,
 
-    /// The command to execute.
+    /// The command to execute if there are no arguments.
     pub cmd_argv0: Option<String>,
 
-    /// The arguments to the command, if any.
+    /// The command and arguments if it has any.
     #[arg(last = true)]
     pub cmd_argv: Vec<String>,
 }


### PR DESCRIPTION
(Don't know if this is a regression or a bug in the docs. This would be to improve the docs if it's the latter...)

This change updates the documentation to be more explicit about where to put command and arguments for `shadowenv exec` (and fixing some typos).

The previous documentation suggested that program arguments need to be specified after a `--`. But it's actually both the command name and the arguments.

The old text:

```
$ shadowenv exec --help
...
USAGE:
    shadowenv exec [OPTIONS] <child-argv0|child-argv> [child-argv0] [-- <child-argv>...]

ARGS:
    <child-argv0>      If the command takes no arguments, it can be passed directly as the last arugment.
    <child-argv>...    If the command requires arguments, they must all be passed after a --.
```

This is in contrast of how it actually works.

Bad:

```
$ shadowenv exec ls -- /
error: The argument '<child-argv>...' cannot be used with one or more of
  the other specified arguments
```
Good:

```
$ shadowenv exec -- ls /
Applications    cores           etc ...
```
