### PR TITLE
Remove outdated zsh prefix

### DIFF
--- a/sh/shadowenv.zsh.in
+++ b/sh/shadowenv.zsh.in
@@ -1,6 +1,6 @@
 __shadowenv_hook() {
   local flags; flags=()
-  if [[ "$1" == "zsh-preexec" ]]; then
+  if [[ "$1" == "preexec" ]]; then
     flags=(--silent)
   fi
   if [[ -n $__shadowenv_force_run ]]; then


### PR DESCRIPTION
Hookbook hasn't used the zsh prefix since [5349cb3e](https://github.com/Shopify/hookbook/commit/5349cb3e5226dcf1800477db8f0ea1ded834bf71#diff-12708494d4f3232104e68131f055dceaed56e64256baf6252d7ec026bbe56944L43-R44)