### PR TITLE
Bump memory limit

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -99,7 +99,7 @@ impl ShadowLang {
         // The default limit of 256 then means a limit of 256 bytes of string per invocation.
         // We'll increase this to 8k, in case people want to embed an RSA cert or something (don't
         // construe this as an endorsement of that plan).
-        restrictions.memory_limit = 8192;
+        restrictions.memory_limit = 65536;
 
         let interp = ketos::Builder::new()
             .restrict(restrictions)


### PR DESCRIPTION
In some projects $NIX_CFLAGS_COMPILE now exceeds 10k. Maybe we should make this configurable, but it also feels reasonable to just support whatever the system supports. The maximum length appears to depend on the platform -- PAGE_SIZE * 32 on Linux (usually 128 KiB), and capped by ARG_MAX on macOS (256 KiB across all args). 64 KiB ought to be enough for anyone.