### PR TITLE
Handle empty lisp files

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -281,7 +281,7 @@ impl ShadowLang {
 
         for source_file in &files {
             let fname = format!("__shadowenv__{}", source_file.name);
-            let prog = format!("(define ({} env) (do {}))", fname, source_file.contents);
+            let prog = format!("(define ({} env) (do () {}))", fname, source_file.contents);
 
             // TODO: error type?
             if let Err(err) = interp.run_code(&prog, Some(source_file.name.to_string())) {
@@ -351,6 +351,27 @@ mod tests {
 
         let result =
             ShadowLang::run_programs(shadowenv, SourceList::new_with_sources(vec![source]));
+        let env = result.unwrap().exports().unwrap();
+
+        assert_eq!(env["VAL_A"].as_ref().unwrap(), "42");
+    }
+
+    #[test]
+    fn test_empty_source() {
+        let shadowenv = build_shadow_env(vec![]);
+
+        let empty_source = build_source(
+            r#""#,
+        );
+
+        let other_source = build_source(
+            r#"
+            (env/set "VAL_A" "42")
+            "#,
+        );
+
+        let result =
+            ShadowLang::run_programs(shadowenv, SourceList::new_with_sources(vec![empty_source, other_source]));
         let env = result.unwrap().exports().unwrap();
 
         assert_eq!(env["VAL_A"].as_ref().unwrap(), "42");


### PR DESCRIPTION
An empty lisp file currently results in

```
compile error: `do` expected at least 1 argument; found 0

Traceback:

  In main, define __shadowenv__900_rx_dev_yaml_env.lisp
  In main, operator do
    (do)
```

on `shadowenv hook`.

While an empty lisp file is not particularly useful, it shouldn't break shadowenv. By adding an empty `()` before the actual content, we ensure the program we create is valid, without changing the behaviour of any lisp file that has content.