### PR TITLE
Make use of nushell's autoload directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@ some limited ability to make the manipulations dynamic.
 ![shadowenv in action](https://burkelibbey.s3.amazonaws.com/shadowenv.gif)
 
 In order to use shadowenv, add a line to your shell profile (`.zshrc`, `.bash_profile`,
-`config.fish`, or `config.nu`) reading:
+or `config.fish`) reading:
 
 ```bash
 eval "$(shadowenv init bash)" # for bash
 eval "$(shadowenv init zsh)"  # for zsh
 shadowenv init fish | source  # for fish
-# for nushell, paste the output of `shadowenv init nushell` into config.nu
 ```
+
+For nushell, run `shadowenv init nushell` which will install a hook into nushell's autoload directory.
 
 With this code loaded, upon entering a directory containing a `.shadowenv.d` directory,
 any `*.lisp` files in that directory will be executed and you will see "activated shadowenv." in your

--- a/src/exec_cmd.rs
+++ b/src/exec_cmd.rs
@@ -7,7 +7,7 @@ pub fn run(cmd: ExecCmd) -> Result<(), Error> {
     let data = Shadowenv::from_env();
     let pathbuf = cmd
         .dir
-        .map(|d| PathBuf::from(d))
+        .map(PathBuf::from)
         .unwrap_or(get_current_dir_or_exit());
 
     if let Some(shadowenv) = hook::load_env(pathbuf, data, true, false)? {

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -53,7 +53,7 @@ impl ShadowenvWrapper {
     fn new(shadowenv: Shadowenv) -> Self {
         Self(RefCell::new(shadowenv))
     }
-    fn borrow_mut_env(&self) -> std::cell::RefMut<Shadowenv> {
+    fn borrow_mut_env(&self) -> std::cell::RefMut<'_, Shadowenv> {
         self.0.borrow_mut()
     }
     fn borrow_env(&self) -> Ref<'_, Shadowenv> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,12 +21,18 @@ fn main() {
     use cli::ShadowenvApp::*;
 
     let result = match cli::ShadowenvApp::parse() {
-        Diff(cmd) => Ok(diff::run(cmd)),
+        Diff(cmd) => {
+            diff::run(cmd);
+            Ok(())
+        }
         Exec(cmd) => exec_cmd::run(cmd),
         Hook(cmd) => hook::run(cmd),
-        Init(cmd) => Ok(init::run(cmd)),
+        Init(cmd) => init::run(cmd),
         Trust(_) => trust::run(),
-        PromptWidget(_) => Ok(prompt_widget::run()),
+        PromptWidget(_) => {
+            prompt_widget::run();
+            Ok(())
+        }
     };
 
     if let Err(err) = result {


### PR DESCRIPTION
## Summary

Changes `shadowenv init nushell` to automatically install the shell hook into nushell's autoload directory instead of printing a script for users to manually paste into their config.

## Changes

- **`src/init.rs`**: Added `install_nushell_hook()` function that:
  - Queries nushell for its autoload directory via `nu -c '$nu.user-autoload-dirs | first'`
  - Creates the autoload directory if it doesn't exist
  - Writes `shadowenv.nu` with the hook script
  - Returns `Result<()>` for proper error handling

- **`src/main.rs`**: Updated to handle the new return type from `init::run()`

- **`README.md`**: Updated nushell instructions to reflect the new behavior

## Behavior

Before:
```
$ shadowenv init nushell
# prints script to stdout, user must paste into config.nu
```

After:
```
$ shadowenv init nushell
Wrote shadowenv hook to /Users/you/Library/Application Support/nushell/autoload/shadowenv.nu
```

The autoload directory is queried from nushell itself, so it works correctly across platforms (macOS, Linux) and respects any custom configuration.