### PR TITLE
Fix `init` resolving argv[0] to `$PWD/shadowenv` for bare invocations

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -1,5 +1,6 @@
 use crate::cli::InitCmd::{self, *};
 use anyhow::{anyhow, Context, Result};
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -7,15 +8,10 @@ use std::process::Command;
 /// print a script that can be sourced into the provided shell, and sets up the shadowenv shell
 /// hooks.
 pub fn run(cmd: InitCmd) -> Result<()> {
-    // Attempt to resolve the path which was passed to argv[0]
-    // This is to avoid the situation where fully resolving to something like a nix
-    // store path could be garbage collected while the shell hook is still used
+    // Resolve argv[0] to an absolute path so the generated shell hook can invoke
+    // shadowenv from any working directory.
     let exe = std::env::args().next().unwrap();
-    let pb = if Path::new(&exe).is_absolute() {
-        PathBuf::from(exe)
-    } else {
-        std::env::current_dir().unwrap().join(exe)
-    };
+    let pb = resolve_self_path(&exe);
     match cmd {
         Bash(opts) => print_script(
             pb,
@@ -34,6 +30,79 @@ pub fn run(cmd: InitCmd) -> Result<()> {
         ),
         Nushell => install_nushell_hook(pb),
     }
+}
+
+/// Resolve the path passed as argv[0] to an absolute path to the shadowenv
+/// executable, suitable for embedding in a shell hook.
+///
+/// We deliberately avoid [`std::env::current_exe`] for the common cases because
+/// it canonicalizes symlinks. Resolving to something like a Nix store path could
+/// later be garbage collected while the shell hook is still in use, so we prefer
+/// a stable path (e.g. a package-manager-managed symlink found on `$PATH`).
+fn resolve_self_path(exe: &str) -> PathBuf {
+    resolve_self_path_inner(
+        exe,
+        std::env::current_dir().ok(),
+        std::env::var_os("PATH"),
+        || std::env::current_exe().ok(),
+    )
+}
+
+fn resolve_self_path_inner(
+    exe: &str,
+    cwd: Option<PathBuf>,
+    path_var: Option<impl AsRef<OsStr>>,
+    current_exe: impl Fn() -> Option<PathBuf>,
+) -> PathBuf {
+    let path = Path::new(exe);
+    if path.is_absolute() {
+        // Already absolute, e.g. invoked via `/usr/local/bin/shadowenv`.
+        return path.to_path_buf();
+    }
+
+    if exe.contains(std::path::MAIN_SEPARATOR) {
+        // A relative path containing a separator (e.g. `./shadowenv` or
+        // `bin/shadowenv`) is resolved against the current directory.
+        if let Some(cwd) = &cwd {
+            return cwd.join(exe);
+        }
+    } else if let Some(found) = path_var.and_then(|p| find_in_path(exe, p.as_ref())) {
+        // A bare command name (no separator) was located by the shell via
+        // `$PATH`. Search `$PATH` ourselves to recover an absolute path rather
+        // than incorrectly joining the name with the current directory.
+        return found;
+    }
+
+    // Fall back to the canonical executable path. This may resolve symlinks, but
+    // a correct absolute path is better than one that does not exist.
+    current_exe()
+        .or_else(|| cwd.map(|cwd| cwd.join(exe)))
+        .unwrap_or_else(|| PathBuf::from(exe))
+}
+
+/// Search the directories in `$PATH` for an executable file named `name`,
+/// returning the first match. Symlinks are intentionally not resolved.
+fn find_in_path(name: &str, path_var: &OsStr) -> Option<PathBuf> {
+    std::env::split_paths(path_var).find_map(|dir| {
+        if dir.as_os_str().is_empty() {
+            return None;
+        }
+        let candidate = dir.join(name);
+        is_executable(&candidate).then_some(candidate)
+    })
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    fs::metadata(path)
+        .map(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
 }
 
 fn install_nushell_hook(selfpath: PathBuf) -> Result<()> {
@@ -88,4 +157,94 @@ fn print_script(selfpath: PathBuf, bytes: &[u8], no_hookbook: bool) -> Result<()
         println!("{}", script);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    const FAKE_CURRENT_EXE: &str = "/canonical/path/shadowenv";
+
+    fn current_exe() -> Option<PathBuf> {
+        Some(PathBuf::from(FAKE_CURRENT_EXE))
+    }
+
+    #[test]
+    fn absolute_argv0_is_used_verbatim() {
+        let got = resolve_self_path_inner(
+            "/usr/local/bin/shadowenv",
+            Some(PathBuf::from("/some/cwd")),
+            Some(OsString::from("/usr/local/bin")),
+            current_exe,
+        );
+        assert_eq!(got, PathBuf::from("/usr/local/bin/shadowenv"));
+    }
+
+    #[test]
+    fn relative_argv0_with_separator_is_joined_with_cwd() {
+        let got = resolve_self_path_inner(
+            "./shadowenv",
+            Some(PathBuf::from("/work/dir")),
+            Some(OsString::from("/usr/bin")),
+            current_exe,
+        );
+        assert_eq!(got, PathBuf::from("/work/dir/./shadowenv"));
+    }
+
+    #[test]
+    fn bare_argv0_is_resolved_via_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("shadowenv");
+        fs::write(&exe, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&exe, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let got = resolve_self_path_inner(
+            "shadowenv",
+            // A bare name must NOT be resolved against the current directory.
+            Some(PathBuf::from("/should/not/be/used")),
+            Some(OsString::from(dir.path())),
+            current_exe,
+        );
+        assert_eq!(got, exe);
+    }
+
+    #[test]
+    fn bare_argv0_never_joins_cwd() {
+        // Regression test for the `$PWD/shadowenv` bug: a bare command name that
+        // cannot be found on $PATH must fall back to the canonical exe path,
+        // never to `<cwd>/shadowenv`.
+        let cwd = PathBuf::from("/Users/someone/project");
+        let got = resolve_self_path_inner(
+            "shadowenv",
+            Some(cwd.clone()),
+            Some(OsString::from("/nonexistent-dir-abc")),
+            current_exe,
+        );
+        assert_ne!(got, cwd.join("shadowenv"));
+        assert_eq!(got, PathBuf::from(FAKE_CURRENT_EXE));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn find_in_path_skips_empty_entries_and_non_executables() {
+        let dir = tempfile::tempdir().unwrap();
+        // A non-executable file with the right name should be skipped.
+        let non_exec = dir.path().join("shadowenv");
+        fs::write(&non_exec, b"not executable\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&non_exec, fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        // PATH with a leading empty entry (":") and the dir holding the
+        // non-executable file: nothing should match.
+        let path_var = OsString::from(format!(":{}", dir.path().display()));
+        assert_eq!(find_in_path("shadowenv", &path_var), None);
+    }
 }


### PR DESCRIPTION
## Problem

When a shell finds `shadowenv` via `$PATH`, `argv[0]` is the bare name `shadowenv` (not absolute, no separator). `shadowenv init <shell>` resolved that to an absolute path with:

```rust
let exe = std::env::args().next().unwrap();
let pb = if Path::new(&exe).is_absolute() {
    PathBuf::from(exe)
} else {
    std::env::current_dir().unwrap().join(exe)   // ← bare names get $PWD/shadowenv
};
```

For a bare name this produces `$PWD/shadowenv`, which is then embedded into the generated shell hook (`eval "$("$PWD/shadowenv" hook ...)"`). As soon as you're in any directory that doesn't contain a `shadowenv` binary, every prompt fails:

```
bash: /Users/me/some/project/shadowenv: No such file or directory
```

This reproduces with a `$PATH`-installed shadowenv (e.g. via Nix/symlink) and a standard `eval "$(shadowenv init bash)"` in `.bash_profile`.

## Fix

`resolve_self_path` now handles the three argv[0] shapes correctly:

- **absolute** → used verbatim
- **relative with a separator** (`./shadowenv`, `bin/shadowenv`) → joined with the cwd (unchanged behaviour)
- **bare name** → looked up on `$PATH`

The original intent of avoiding `std::env::current_exe()` (so a stable symlink is preferred over a canonicalized, potentially garbage-collected Nix store path) is preserved: `$PATH` lookup returns the symlink path without canonicalizing, and `current_exe()` is used only as a last-resort fallback — never `$PWD/<name>`.

The resolution logic is split into a pure `resolve_self_path_inner` (cwd, `$PATH`, and `current_exe` injected) so it can be unit-tested without mutating process-global state.

## Tests

Adds unit tests for each case, including a regression test asserting a bare name is never resolved to `$PWD/shadowenv`. Full suite passes (`cargo test`), `cargo fmt --check` is clean, and `cargo clippy` reports no new warnings for `src/init.rs`.