### PR TITLE
Make bash and zsh hooks safe under nounset

### DIFF
--- a/sh/shadowenv.bash.in
+++ b/sh/shadowenv.bash.in
@@ -3,7 +3,7 @@ __shadowenv_hook() {
   if [[ "$1" == "preexec" ]]; then
     flags+=(--silent)
   fi
-  if [[ -n $__shadowenv_force_run ]]; then
+  if [[ -n ${__shadowenv_force_run:-} ]]; then
     flags+=(--force)
     unset __shadowenv_force_run
   fi

--- a/sh/shadowenv.zsh.in
+++ b/sh/shadowenv.zsh.in
@@ -3,7 +3,7 @@ __shadowenv_hook() {
   if [[ "$1" == "preexec" ]]; then
     flags=(--silent)
   fi
-  if [[ -n $__shadowenv_force_run ]]; then
+  if [[ -n ${__shadowenv_force_run:-} ]]; then
     flags+=(--force)
     unset __shadowenv_force_run
   fi

--- a/src/init.rs
+++ b/src/init.rs
@@ -247,4 +247,28 @@ mod tests {
         let path_var = OsString::from(format!(":{}", dir.path().display()));
         assert_eq!(find_in_path("shadowenv", &path_var), None);
     }
+
+    #[test]
+    fn generated_hooks_tolerate_nounset_after_force_run() {
+        for (shell, template) in [
+            ("bash", include_bytes!("../sh/shadowenv.bash.in") as &[u8]),
+            ("zsh", include_bytes!("../sh/shadowenv.zsh.in") as &[u8]),
+        ] {
+            let script = String::from_utf8_lossy(template)
+                .replace("@SELF@", "true")
+                .replace("@HOOKBOOK@", "hookbook_add_hook() { :; }");
+            let script = format!("{script}\n__shadowenv_hook preexec\n__shadowenv_hook preexec\n");
+            let output = Command::new("bash")
+                .args(["-u", "-c"])
+                .arg(script)
+                .output()
+                .expect("bash should be available to test generated shell hooks");
+
+            assert!(
+                output.status.success(),
+                "{shell} hook failed under nounset after consuming its force flag:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
 }


### PR DESCRIPTION
# TL;DR

Make the generated bash and zsh hooks safe when the caller enables `set -u` or zsh `NO_UNSET`.

# Context

The generated hook sets `__shadowenv_force_run` once, consumes it during the first hook invocation, and then unsets it. Every later invocation dereferenced the now-missing variable directly, aborting nounset-enabled shells before their command could run.

This is particularly disruptive when `shadowenv init` is sourced from a login profile: the error is attributed to the profile rather than shadowenv, and strict automation fails before executing its payload.

Closes https://github.com/Shopify/shadowenv/issues/169

# Changes

- Default `__shadowenv_force_run` to an empty value in the bash hook guard.
- Apply the same nounset-safe expansion to the zsh hook guard.
- Add a regression test that renders both templates and invokes each hook twice under nounset. The second invocation exercises the state after the one-shot force flag has been unset.

The existing first-run `--force` behavior is unchanged.

# Tophatting

- `dev style`
- `dev test` — 34 tests pass
- Confirmed the regression test's harness fails against both pre-change templates with `__shadowenv_force_run: unbound variable`.
- Confirmed the patched zsh template survives two hook calls under native `zsh -f -u`.
