### PR TITLE
Reject environment variable names that can't be represented in the output

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -75,6 +75,57 @@ $ shadowenv hook --pretty-json ''
 Note that we've added a "schema" field, and that schema v3 will almost certainly remove the
 "unexported" element, so make sure not to depend on its presence.
 
+### Applying variables safely
+
+Variable names and values both come from the `.shadowenv.d` programs Shadowenv evaluates, which
+can produce any text. Apply them through whatever API your language provides for *setting* an
+environment variable, and never by building a string that your language then evaluates.
+
+Concretely, in Vim script this is wrong, because the name is re-parsed as part of the command, so
+one containing `|` or `"` is interpreted rather than used:
+
+```vim
+execute('let $' . name . ' = value')  " don't
+```
+
+and this is right, because the name is passed as data:
+
+```vim
+call setenv(name, value)              " do
+```
+
+The same distinction applies anywhere else: prefer `setenv`/`os.environ`/`ENV[]` over `eval`,
+and prefer passing an argument vector over interpolating into a shell command.
+
+### The `--porcelain` format
+
+`--porcelain` emits one record per variable, terminated by `0x1E`. Each record is a list of fields
+separated by `0x1F`:
+
+```
+<opcode> 0x1F <name> 0x1F <value> 0x1E
+```
+
+The opcodes are `0x01` (set, unexported — unused), `0x02` (set, exported) and `0x03` (unset, with
+an empty value field). There is a trailing record separator, but don't depend on that staying true.
+
+Shadowenv guarantees that a **name** never contains `0x1E`, `0x1F`, `=`, a newline, a carriage
+return, or a NUL, and is never empty. Names that would violate this are rejected when a
+`.shadowenv.d` program assigns them, and omitted from this output if one reaches it by some other
+route (for example a `$__shadowenv_data` written by an older version, in which case a warning goes
+to stderr). You can therefore split records and fields positionally without escaping.
+
+That guarantee is about *framing only*. A name is still arbitrary text — `FOO BAR`, `FOO-BAR` and
+`FOO | id` are all valid names that reach you — so it is not safe to interpolate one into anything
+your language evaluates. See "Applying variables safely" above.
+
+No such guarantee is made about **values**, which may contain any byte except `0x1E` and `0x1F`.
+
+Names are deliberately *not* quoted or escaped in this format. It is a binary protocol that nothing
+evaluates as a shell command, so escaping would only make the escape characters part of the name a
+consumer reads back. The shell-evaluated modes (default and `--fish`) do quote both names and
+values, because there the output really is evaluated by a shell.
+
 Our suggestion moving forward into 2.0.0 and later is to treat "unexported" values read from 1.3.2
 and earlier the same as "exported" values.
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -4,15 +4,18 @@ use crate::{
     hash::{Hash, SourceList},
     lang::{self, ShadowLang},
     loader, output,
-    shadowenv::Shadowenv,
+    shadowenv::{validate_var_name, Shadowenv},
     trust::ensure_dir_tree_trusted,
     undo, unsafe_getppid,
 };
 use anyhow::{anyhow, Error};
 use serde_derive::Serialize;
 use shell_escape as shell;
-use std::{borrow::Cow, collections::HashMap, env, path::PathBuf, result::Result, str::FromStr};
+use std::{
+    borrow::Cow, collections::HashMap, env, io::Write, path::PathBuf, result::Result, str::FromStr,
+};
 
+#[derive(Clone, Copy)]
 pub enum VariableOutputMode {
     Fish,
     Porcelain,
@@ -173,6 +176,13 @@ fn load_trusted_sources(
 
 pub fn mutate_own_env(shadowenv: &Shadowenv) -> Result<(), Error> {
     for (k, v) in shadowenv.exports()? {
+        // `env::set_var` panics on a name containing '=' or NUL. Names are
+        // rejected when a program assigns them, but a $__shadowenv_data written
+        // by an older version can still carry one, so skip rather than abort.
+        if let Err(err) = validate_var_name(&k) {
+            eprintln!("shadowenv: skipping variable: {}", err);
+            continue;
+        }
         match v {
             Some(s) => env::set_var(k, &s),
             None => env::remove_var(k),
@@ -183,44 +193,66 @@ pub fn mutate_own_env(shadowenv: &Shadowenv) -> Result<(), Error> {
 }
 
 pub fn apply_env(shadowenv: &Shadowenv, mode: VariableOutputMode) -> Result<(), Error> {
+    let exports = shadowenv.exports()?;
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    write_exports(&mut out, &exports, mode)?;
+    out.flush()?;
+
     match mode {
-        VariableOutputMode::Posix => {
-            for (k, v) in shadowenv.exports()? {
-                match v {
-                    Some(s) => println!("export {}={}", shell_escape(&k), shell_escape(&s)),
-                    None => println!("unset {}", shell_escape(&k)),
-                }
-            }
+        VariableOutputMode::Posix | VariableOutputMode::Fish => {
             output::print_activation_to_tty(
                 shadowenv.current_dirs(),
                 shadowenv.prev_dirs(),
                 shadowenv.features(),
             );
         }
+        VariableOutputMode::Porcelain
+        | VariableOutputMode::Json
+        | VariableOutputMode::PrettyJson => {}
+    }
+
+    Ok(())
+}
+
+/// Render the variable assignments for `mode`. Separate from `apply_env` so
+/// that tests can assert on the exact bytes each mode produces: the escaping
+/// rules differ per mode and are only correct if checked at this boundary.
+fn write_exports<W: Write>(
+    out: &mut W,
+    exports: &HashMap<String, Option<String>>,
+    mode: VariableOutputMode,
+) -> Result<(), Error> {
+    match mode {
+        VariableOutputMode::Posix => {
+            for (k, v) in exports {
+                match v {
+                    Some(s) => writeln!(out, "export {}={}", shell_escape(k), shell_escape(s))?,
+                    None => writeln!(out, "unset {}", shell_escape(k))?,
+                }
+            }
+        }
         VariableOutputMode::Fish => {
-            for (k, v) in shadowenv.exports()? {
+            for (k, v) in exports {
                 match v {
                     Some(s) => {
                         if k == "PATH" {
-                            println!(
+                            writeln!(
+                                out,
                                 "set -gx {} (string split : -- {})",
-                                shell_escape(&k),
-                                shell_escape(&s)
-                            );
+                                shell_escape(k),
+                                shell_escape(s)
+                            )?;
                         } else {
-                            println!("set -gx {} {}", shell_escape(&k), shell_escape(&s));
+                            writeln!(out, "set -gx {} {}", shell_escape(k), shell_escape(s))?;
                         }
                     }
                     None => {
-                        println!("set -e {}", shell_escape(&k));
+                        writeln!(out, "set -e {}", shell_escape(k))?;
                     }
                 }
             }
-            output::print_activation_to_tty(
-                shadowenv.current_dirs(),
-                shadowenv.prev_dirs(),
-                shadowenv.features(),
-            );
         }
         VariableOutputMode::Porcelain => {
             // three fields: <operation> : <name> : <value>
@@ -229,20 +261,35 @@ pub fn apply_env(shadowenv: &Shadowenv, mode: VariableOutputMode) -> Result<(), 
             //          3: unset (value is empty)
             // field separator is 0x1F; record separator is 0x1E. There's a trailing record
             // separator because I'm lazy but don't depend on it not going away.
-            for (k, v) in shadowenv.exports()? {
+            //
+            // Names are NOT shell-escaped here: this is a binary protocol, not
+            // something a shell evaluates, and quoting a name would make the
+            // quotes part of the name a consumer reads back. What consumers do
+            // need is the guarantee that a name never contains a separator, so
+            // that records stay parseable positionally. Names are rejected at
+            // assignment time; this also drops any that survive in a
+            // $__shadowenv_data written by an older version.
+            for (k, v) in exports {
+                if let Err(err) = validate_var_name(k) {
+                    eprintln!(
+                        "shadowenv: omitting variable from porcelain output: {}",
+                        err
+                    );
+                    continue;
+                }
                 match v {
-                    Some(s) => print!("\x02\x1F{}\x1F{}\x1E", k, s),
-                    None => print!("\x03\x1F{}\x1F\x1E", k),
+                    Some(s) => write!(out, "\x02\x1F{}\x1F{}\x1E", k, s)?,
+                    None => write!(out, "\x03\x1F{}\x1F\x1E", k)?,
                 }
             }
         }
         VariableOutputMode::Json => {
-            let modifs = Modifications::new(shadowenv.exports()?);
-            println!("{}", serde_json::to_string(&modifs).unwrap());
+            let modifs = Modifications::new(exports.clone());
+            writeln!(out, "{}", serde_json::to_string(&modifs).unwrap())?;
         }
         VariableOutputMode::PrettyJson => {
-            let modifs = Modifications::new(shadowenv.exports()?);
-            println!("{}", serde_json::to_string_pretty(&modifs).unwrap());
+            let modifs = Modifications::new(exports.clone());
+            writeln!(out, "{}", serde_json::to_string_pretty(&modifs).unwrap())?;
         }
     }
     Ok(())
@@ -258,6 +305,7 @@ mod tests {
     use crate::undo::Data;
     use std::fs;
     use tempfile::tempdir;
+    use VariableOutputMode::{Fish, Porcelain, Posix};
 
     #[test]
     fn load_trusted_source_returns_an_error_for_untrusted_folders() {
@@ -310,6 +358,27 @@ mod tests {
         assert!(sources[1].dir.ends_with("dir1/dir2"));
     }
 
+    fn render(exports: &[(&str, Option<&str>)], mode: VariableOutputMode) -> String {
+        let map: HashMap<String, Option<String>> = exports
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.map(|s| s.to_string())))
+            .collect();
+        let mut buf: Vec<u8> = Vec::new();
+        write_exports(&mut buf, &map, mode).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    /// Records are emitted in HashMap order, so compare them as a set.
+    fn porcelain_records(out: &str) -> Vec<String> {
+        let mut records: Vec<String> = out
+            .split('\x1e')
+            .filter(|r| !r.is_empty())
+            .map(|r| r.to_string())
+            .collect();
+        records.sort();
+        records
+    }
+
     #[test]
     fn test_apply_env_escapes_variable_names() {
         // Test that shell_escape properly escapes dangerous characters
@@ -322,30 +391,103 @@ mod tests {
         assert_eq!(shell_escape("VAR`command`"), "'VAR`command`'");
         assert_eq!(shell_escape("VAR'with'quotes"), "'VAR'\\''with'\\''quotes'");
 
-        // Create a shadowenv with potentially malicious variable names as new variables
-        let initial_env = HashMap::new(); // Empty initial env
-        let mut env = initial_env.clone();
-        env.insert("NORMAL_VAR".to_string(), "normal_value".to_string());
-        env.insert(
-            "TEST=AA; touch pwned.txt; #".to_string(),
-            "value".to_string(),
+        // The shell-evaluated modes must quote the *name* as well as the value,
+        // or a name carrying shell metacharacters is reinterpreted by the shell
+        // that evaluates this output.
+        let out = render(&[("TEST=AA; touch pwned.txt; #", Some("value"))], Posix);
+        assert_eq!(out, "export 'TEST=AA; touch pwned.txt; #'=value\n");
+
+        let out = render(&[("VAR$(command)", None)], Posix);
+        assert_eq!(out, "unset 'VAR$(command)'\n");
+
+        let out = render(&[("VAR`command`", Some("v"))], Fish);
+        assert_eq!(out, "set -gx 'VAR`command`' v\n");
+    }
+
+    #[test]
+    fn test_porcelain_emits_names_verbatim() {
+        // Porcelain is delimiter-framed and never shell-evaluated, so a name is
+        // emitted as-is. Quoting it here would make the quotes part of the name.
+        let out = render(&[("FOO", Some("bar"))], Porcelain);
+        assert_eq!(out, "\x02\x1FFOO\x1Fbar\x1E");
+
+        let out = render(&[("FOO", None)], Porcelain);
+        assert_eq!(out, "\x03\x1FFOO\x1F\x1E");
+
+        // A name that would need quoting in a shell is still passed through.
+        let out = render(&[("VAR$(command)", Some("v"))], Porcelain);
+        assert_eq!(out, "\x02\x1FVAR$(command)\x1Fv\x1E");
+    }
+
+    #[test]
+    fn test_porcelain_never_emits_separators_inside_a_name() {
+        // A name containing a separator truncates its own record and adds
+        // spurious ones, so it must never reach the stream: consumers parse
+        // positionally and cannot recover the framing themselves.
+        let unrepresentable = "AA\x1e\x02\x1fSPURIOUS\x1fyes";
+        let out = render(
+            &[(unrepresentable, Some("v")), ("GOOD", Some("g"))],
+            Porcelain,
         );
 
-        let mut shadowenv = Shadowenv::new(initial_env, Data::new(), 0, false);
-        // Set the variables using the shadowenv API
-        shadowenv.set("NORMAL_VAR", Some("normal_value"));
-        shadowenv.set("TEST=AA; touch pwned.txt; #", Some("value"));
+        assert_eq!(
+            porcelain_records(&out),
+            vec!["\x02\x1FGOOD\x1Fg".to_string()]
+        );
+        assert!(!out.contains("SPURIOUS"));
 
-        // Test that exports returns the expected data
+        // Every emitted record has exactly the three fields the protocol defines.
+        for record in porcelain_records(&out) {
+            assert_eq!(record.split('\x1f').count(), 3, "record: {:?}", record);
+        }
+    }
+
+    #[test]
+    fn test_porcelain_record_count_matches_variable_count() {
+        let out = render(
+            &[("A", Some("1")), ("B", None), ("C", Some("3"))],
+            Porcelain,
+        );
+        assert_eq!(porcelain_records(&out).len(), 3);
+    }
+
+    #[test]
+    fn test_set_rejects_names_that_break_the_porcelain_protocol() {
+        let mut shadowenv = Shadowenv::new(HashMap::new(), Data::new(), 0, false);
+
+        assert!(shadowenv.set("NORMAL_VAR", Some("normal_value")).is_ok());
+        // Unusual but harmless: representable in every output mode.
+        assert!(shadowenv.set("TEST; touch pwned.txt; #", Some("v")).is_ok());
+
+        for bad in ["AA\x1eBB", "AA\x1fBB", "TEST=AA", "AA\nBB", "AA\0BB", ""] {
+            assert!(
+                shadowenv.set(bad, Some("value")).is_err(),
+                "expected {:?} to be rejected",
+                bad
+            );
+        }
+
+        // Rejected names must not be left behind in the environment.
         let exports = shadowenv.exports().unwrap();
         assert_eq!(
             exports.get("NORMAL_VAR"),
             Some(&Some("normal_value".to_string()))
         );
-        assert_eq!(
-            exports.get("TEST=AA; touch pwned.txt; #"),
-            Some(&Some("value".to_string()))
-        );
+        assert!(exports.keys().all(|k| !k.contains('\x1e')));
+    }
+
+    #[test]
+    fn test_pathlist_helpers_also_reject_unrepresentable_names() {
+        let mut shadowenv = Shadowenv::new(HashMap::new(), Data::new(), 0, false);
+
+        assert!(shadowenv.append_to_pathlist("AA\x1eBB", "/x").is_err());
+        assert!(shadowenv.prepend_to_pathlist("AA\x1fBB", "/x").is_err());
+        assert!(shadowenv.remove_from_pathlist("AA=BB", "/x").is_err());
+        assert!(shadowenv
+            .remove_from_pathlist_containing("AA\nBB", "/x")
+            .is_err());
+
+        assert!(shadowenv.append_to_pathlist("PATH", "/x").is_ok());
     }
 
     #[test]

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -142,7 +142,10 @@ impl ShadowLang {
                 let name = <&str as FromValueRef>::from_value_ref(&args[0])?;
                 let value = <&str as FromValueRef>::from_value_ref(&args[1]).ok();
 
-                shadowenv.borrow_mut_env().set(name, value);
+                shadowenv
+                    .borrow_mut_env()
+                    .set(name, value)
+                    .map_err(ketos::Error::custom)?;
                 Ok(Value::Unit)
             })
         });
@@ -158,7 +161,10 @@ impl ShadowLang {
                     let name = <&str as FromValueRef>::from_value_ref(&args[0])?;
                     let value = <&str as FromValueRef>::from_value_ref(&args[1])?;
 
-                    wrapper.borrow_mut_env().append_to_pathlist(name, value);
+                    wrapper
+                        .borrow_mut_env()
+                        .append_to_pathlist(name, value)
+                        .map_err(ketos::Error::custom)?;
                     Ok(Value::Unit)
                 })
             });
@@ -174,7 +180,10 @@ impl ShadowLang {
                     let name = <&str as FromValueRef>::from_value_ref(&args[0])?;
                     let value = <&str as FromValueRef>::from_value_ref(&args[1])?;
 
-                    wrapper.borrow_mut_env().prepend_to_pathlist(name, value);
+                    wrapper
+                        .borrow_mut_env()
+                        .prepend_to_pathlist(name, value)
+                        .map_err(ketos::Error::custom)?;
                     Ok(Value::Unit)
                 })
             });
@@ -190,7 +199,10 @@ impl ShadowLang {
                     let name = <&str as FromValueRef>::from_value_ref(&args[0])?;
                     let value = <&str as FromValueRef>::from_value_ref(&args[1])?;
 
-                    wrapper.borrow_mut_env().remove_from_pathlist(name, value);
+                    wrapper
+                        .borrow_mut_env()
+                        .remove_from_pathlist(name, value)
+                        .map_err(ketos::Error::custom)?;
                     Ok(Value::Unit)
                 })
             });
@@ -208,7 +220,8 @@ impl ShadowLang {
 
                     wrapper
                         .borrow_mut_env()
-                        .remove_from_pathlist_containing(name, value);
+                        .remove_from_pathlist_containing(name, value)
+                        .map_err(ketos::Error::custom)?;
                     Ok(Value::Unit)
                 })
             });
@@ -354,6 +367,38 @@ mod tests {
         let env = result.unwrap().exports().unwrap();
 
         assert_eq!(env["VAL_A"].as_ref().unwrap(), "42");
+    }
+
+    #[test]
+    fn test_env_set_rejects_names_containing_porcelain_separators() {
+        // Names come from shadowlisp, which can produce any text. 0x1E/0x1F are
+        // the porcelain record and field separators, so a name containing one
+        // corrupts the framing of the output editor integrations parse.
+        for bad in [
+            r#"(env/set "AA\x1e\x02\x1fSPURIOUS\x1fyes" "v")"#,
+            r#"(env/set "AA\x1fBB" "v")"#,
+            r#"(env/set "TEST=AA" "v")"#,
+            r#"(env/append-to-pathlist "AA\x1eBB" "/x")"#,
+        ] {
+            let shadowenv = build_shadow_env(vec![]);
+            let result = ShadowLang::run_programs(
+                shadowenv,
+                SourceList::new_with_sources(vec![build_source(bad)]),
+            );
+            assert!(result.is_err(), "expected {} to be rejected", bad);
+        }
+    }
+
+    #[test]
+    fn test_env_set_still_allows_unusual_but_representable_names() {
+        let shadowenv = build_shadow_env(vec![]);
+        let source = build_source(r#"(env/set "weird.name-with$stuff" "42")"#);
+
+        let result =
+            ShadowLang::run_programs(shadowenv, SourceList::new_with_sources(vec![source]));
+        let env = result.unwrap().exports().unwrap();
+
+        assert_eq!(env["weird.name-with$stuff"].as_ref().unwrap(), "42");
     }
 
     #[test]

--- a/src/shadowenv.rs
+++ b/src/shadowenv.rs
@@ -6,6 +6,61 @@ use std::{
     path::PathBuf,
 };
 
+/// Characters that may never appear in an environment variable name, with the
+/// reason reported to whoever wrote the offending shadowlisp.
+///
+/// 0x1E and 0x1F are the record and field separators of the `--porcelain`
+/// output format. That format is parsed positionally, so a name containing
+/// either one truncates its own record and adds spurious ones. `=` and NUL
+/// cannot occur in a real environment entry at all (`execve` encodes entries as
+/// `NAME=VALUE`, and `std::env::set_var` panics on both), and a newline breaks
+/// every line-oriented consumer.
+const FORBIDDEN_NAME_CHARS: [(char, &str); 6] = [
+    ('\0', "names may not contain a NUL byte"),
+    ('\n', "names may not contain a newline"),
+    ('\r', "names may not contain a carriage return"),
+    ('=', "names may not contain '='"),
+    (
+        '\x1e',
+        "names may not contain 0x1E, the porcelain record separator",
+    ),
+    (
+        '\x1f',
+        "names may not contain 0x1F, the porcelain field separator",
+    ),
+];
+
+#[derive(Debug, thiserror::Error)]
+#[error("invalid environment variable name {name:?}: {reason}")]
+pub struct InvalidVariableName {
+    pub name: String,
+    pub reason: &'static str,
+}
+
+/// Reject environment variable names that cannot be represented faithfully to
+/// downstream consumers. Deliberately narrower than a full POSIX identifier
+/// check: names like `foo.bar` are unusual but round-trip safely through every
+/// output mode, and rejecting them would break existing shadowlisp.
+pub fn validate_var_name(name: &str) -> Result<(), InvalidVariableName> {
+    if name.is_empty() {
+        return Err(InvalidVariableName {
+            name: name.to_string(),
+            reason: "names may not be empty",
+        });
+    }
+
+    for (forbidden, reason) in FORBIDDEN_NAME_CHARS {
+        if name.contains(forbidden) {
+            return Err(InvalidVariableName {
+                name: name.to_string(),
+                reason,
+            });
+        }
+    }
+
+    Ok(())
+}
+
 #[derive(Debug)]
 pub struct Shadowenv {
     /// the mutated/modified env: the final state we want to be in after eval'ing exports.
@@ -154,32 +209,46 @@ impl Shadowenv {
         Ok(changes)
     }
 
-    pub fn set(&mut self, a: &str, b: Option<&str>) {
-        env_set(&mut self.env, a.to_string(), b.map(|s| s.to_string()))
+    pub fn set(&mut self, a: &str, b: Option<&str>) -> Result<(), InvalidVariableName> {
+        validate_var_name(a)?;
+        env_set(&mut self.env, a.to_string(), b.map(|s| s.to_string()));
+        Ok(())
     }
 
     pub fn get(&self, a: &str) -> Option<String> {
         env_get(&self.env, a.to_string())
     }
 
-    pub fn remove_from_pathlist(&mut self, a: &str, b: &str) {
+    pub fn remove_from_pathlist(&mut self, a: &str, b: &str) -> Result<(), InvalidVariableName> {
+        validate_var_name(a)?;
         self.inform_list(a);
-        env_remove_from_pathlist(&mut self.env, a.to_string(), b.to_string())
+        env_remove_from_pathlist(&mut self.env, a.to_string(), b.to_string());
+        Ok(())
     }
 
-    pub fn remove_from_pathlist_containing(&mut self, a: &str, b: &str) {
+    pub fn remove_from_pathlist_containing(
+        &mut self,
+        a: &str,
+        b: &str,
+    ) -> Result<(), InvalidVariableName> {
+        validate_var_name(a)?;
         self.inform_list(a);
-        env_remove_from_pathlist_containing(&mut self.env, a.to_string(), b.to_string())
+        env_remove_from_pathlist_containing(&mut self.env, a.to_string(), b.to_string());
+        Ok(())
     }
 
-    pub fn append_to_pathlist(&mut self, a: &str, b: &str) {
+    pub fn append_to_pathlist(&mut self, a: &str, b: &str) -> Result<(), InvalidVariableName> {
+        validate_var_name(a)?;
         self.inform_list(a);
-        env_append_to_pathlist(&mut self.env, a.to_string(), b.to_string())
+        env_append_to_pathlist(&mut self.env, a.to_string(), b.to_string());
+        Ok(())
     }
 
-    pub fn prepend_to_pathlist(&mut self, a: &str, b: &str) {
+    pub fn prepend_to_pathlist(&mut self, a: &str, b: &str) -> Result<(), InvalidVariableName> {
+        validate_var_name(a)?;
         self.inform_list(a);
-        env_prepend_to_pathlist(&mut self.env, a.to_string(), b.to_string())
+        env_prepend_to_pathlist(&mut self.env, a.to_string(), b.to_string());
+        Ok(())
     }
 
     pub fn add_feature(&mut self, name: &str, version: Option<&str>) {
@@ -340,18 +409,18 @@ mod tests {
     #[test]
     fn test_get_set() {
         let mut shadowenv = build_shadow_env(vec![], Default::default());
-        shadowenv.set("toto", Some("tata"));
+        shadowenv.set("toto", Some("tata")).unwrap();
         assert_eq!(shadowenv.get("toto"), Some("tata".to_string()))
     }
 
     #[test]
     fn test_path_manipulation() {
         let mut shadowenv = build_shadow_env(vec![], Default::default());
-        shadowenv.append_to_pathlist("field1", "v1");
-        shadowenv.prepend_to_pathlist("field1", "v0");
+        shadowenv.append_to_pathlist("field1", "v1").unwrap();
+        shadowenv.prepend_to_pathlist("field1", "v0").unwrap();
 
         assert_eq!(shadowenv.get("field1"), Some("v0:v1".to_string()));
-        shadowenv.remove_from_pathlist("field1", "v0");
+        shadowenv.remove_from_pathlist("field1", "v0").unwrap();
         assert_eq!(shadowenv.get("field1"), Some("v1".to_string()))
     }
 
@@ -361,13 +430,13 @@ mod tests {
             vec![("VAR_A", "v0"), ("VAR_B", "v0"), ("PATH", "/path1:/path2")],
             Default::default(),
         );
-        shadowenv.append_to_pathlist("PATH", "/path3");
-        shadowenv.prepend_to_pathlist("PATH", "/path4");
-        shadowenv.remove_from_pathlist("PATH", "/path1");
+        shadowenv.append_to_pathlist("PATH", "/path3").unwrap();
+        shadowenv.prepend_to_pathlist("PATH", "/path4").unwrap();
+        shadowenv.remove_from_pathlist("PATH", "/path1").unwrap();
 
-        shadowenv.set("VAR_A", Some("v2"));
-        shadowenv.set("VAR_B", None);
-        shadowenv.set("VAR_C", Some("v3"));
+        shadowenv.set("VAR_A", Some("v2")).unwrap();
+        shadowenv.set("VAR_B", None).unwrap();
+        shadowenv.set("VAR_C", Some("v3")).unwrap();
 
         let expected = Data {
             scalars: vec![


### PR DESCRIPTION
Nothing stopped a `.shadowenv.d` program from assigning a variable name that cannot survive the output formats it is then rendered into:

- `--porcelain` is parsed positionally, splitting fields on `0x1F` and records on `0x1E`. A name containing either byte truncates the record it appears in and adds spurious ones, so a consumer silently reads back the wrong set of variables.
- `=` and NUL fail one layer down: `execve` encodes entries as `NAME=VALUE`, and `std::env::set_var` panics on both, so `shadowenv exec` aborted rather than skipping the entry.

Validate names where they are assigned. `env/set` and the four `env/*-pathlist` builtins now return a lisp error naming the offending variable and the reason, instead of accepting something that cannot be represented downstream.

The check is deliberately narrower than a POSIX identifier check: it rejects only NUL, newline, carriage return, `=`, `0x1E`, `0x1F`, and the empty name. Names like `foo.bar` or `FOO BAR` are unusual but round-trip safely through every output mode, and rejecting them would break existing shadowlisp. I checked the generated `.shadowenv.d` in our monorepo and every name there is already a strict identifier, so the blast radius should be nil.

Names are still emitted verbatim in `--porcelain`, which is the correct behaviour: it is a delimiter-framed binary protocol that nothing evaluates, so quoting a name would only make the quotes part of the name a consumer reads back. The shell-evaluated modes keep shell-escaping both names and values. `--porcelain` and `mutate_own_env` additionally skip anything invalid that reaches them by another route, since a `$__shadowenv_data` written by an older version can still carry one.

### Testing and a fixed test

`test_apply_env_escapes_variable_names` asserted on `exports()` and `shell_escape` without ever calling `apply_env`, so it could not have caught a mistake in the rendered output — which is where the escaping rules actually live. Rendering is now split out of `apply_env` into `write_exports`, so tests can assert on the exact bytes each mode produces, and that test now checks real output.

New tests cover porcelain framing (names verbatim, no separators, record count matches variable count) and rejection at both the `Shadowenv` API and the lisp layer, including that an unusual-but-representable name still works. 41 tests pass; `cargo fmt --check` is clean and `cargo clippy` reports no new warnings.

### Docs

Documents the `--porcelain` record layout and the name guarantee in `docs/integration.md`, including that the guarantee is about framing only — a name is still arbitrary text, so it should not be interpolated into anything a consumer evaluates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)